### PR TITLE
Fix mac address ambiguity

### DIFF
--- a/station/Classes/Model/Ontology/Identifier/Identifier.swift
+++ b/station/Classes/Model/Ontology/Identifier/Identifier.swift
@@ -14,9 +14,7 @@ protocol MACIdentifier: Identifier {
 struct MACIdentifierStruct: MACIdentifier {
     var value: String
     var mac: String {
-        return String(value
-            .replacingOccurrences(of: ":", with: "")
-            .prefix(12))
+        return value
     }
 }
 
@@ -27,9 +25,7 @@ struct AnyMACIdentifier: MACIdentifier, Equatable, Hashable {
         return object.value
     }
     var mac: String {
-        return String(object.value
-            .replacingOccurrences(of: ":", with: "")
-            .prefix(12))
+        return object.value
     }
 
     static func == (lhs: AnyMACIdentifier, rhs: AnyMACIdentifier) -> Bool {


### PR DESCRIPTION
Hey @viikufa. 

Here https://github.com/ruuvi/com.ruuvi.station.ios/commit/c1756bb9b4ad9ed4559e81a5495adc24cdb459f5 you've introduced macId colon crop. Could you please verify that we can get rid of this ambiguity in MAC address representation> 