### PR TITLE
Remove SwinjectPropertyLoader

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -85,7 +85,6 @@ def shared_pods
   pod 'RuuviVirtual/Service', :path => 'Packages/RuuviVirtual/RuuviVirtual.podspec'
   pod 'RuuviVirtual/OWM', :path => 'Packages/RuuviVirtual/RuuviVirtual.podspec'
   pod 'Swinject'
-  pod 'SwinjectPropertyLoader', :git => 'https://github.com/rinat-enikeev/SwinjectPropertyLoader'
   pod 'SwiftGen', '~> 6.0'
   pod 'KeychainAccess'
   pod 'iOSDFULibrary'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -513,8 +513,6 @@ PODS:
   - RuuviVirtual/Tests (0.0.1)
   - SwiftGen (6.4.0)
   - Swinject (2.8.1)
-  - SwinjectPropertyLoader (1.0.2):
-    - Swinject (~> 2.8.1)
   - ZIPFoundation (0.9.11)
 
 DEPENDENCIES:
@@ -620,7 +618,6 @@ DEPENDENCIES:
   - RuuviVirtual/Tests (from `Packages/RuuviVirtual/RuuviVirtual.podspec`)
   - SwiftGen (~> 6.0)
   - Swinject
-  - SwinjectPropertyLoader (from `https://github.com/rinat-enikeev/SwinjectPropertyLoader`)
 
 SPEC REPOS:
   trunk:
@@ -703,8 +700,6 @@ EXTERNAL SOURCES:
     :path: Packages/RuuviUser/RuuviUser.podspec
   RuuviVirtual:
     :path: Packages/RuuviVirtual/RuuviVirtual.podspec
-  SwinjectPropertyLoader:
-    :git: https://github.com/rinat-enikeev/SwinjectPropertyLoader
 
 CHECKOUT OPTIONS:
   Humidity:
@@ -716,9 +711,6 @@ CHECKOUT OPTIONS:
   RangeSeekSlider:
     :commit: 35712fc13229f527e0a356f3de34deccbcfd6b59
     :git: https://github.com/rinat-enikeev/RangeSeekSlider
-  SwinjectPropertyLoader:
-    :commit: d7bc69bfcbc6da6a473ba3f208c18fd4b0c184bb
-    :git: https://github.com/rinat-enikeev/SwinjectPropertyLoader
 
 SPEC CHECKSUMS:
   BTKit: c409ccfad57a372438db9b4951687289ba14c4c9
@@ -774,9 +766,8 @@ SPEC CHECKSUMS:
   RuuviVirtual: ac6530563120c022842cc2f2ff9e8c1237f36eb6
   SwiftGen: 67860cc7c3cfc2ed25b9b74cfd55495fc89f9108
   Swinject: 97112918bd7e0785dc2df7036213f3c8cbba6586
-  SwinjectPropertyLoader: fd78f00ba21abced30b053ca55a42af32174580e
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 12b04e7e059d5bc0479201b29636f0bd96d25b0a
+PODFILE CHECKSUM: 10e4d919531d9e2010759be9f6e01efdf0b29d17
 
 COCOAPODS: 1.11.2

--- a/station.xcodeproj/project.pbxproj
+++ b/station.xcodeproj/project.pbxproj
@@ -771,6 +771,8 @@
 		7350803A8D6DD23F1057994F /* SignInPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29B5190CB557178D11AB2CE /* SignInPresenter.swift */; };
 		73949279A33A1BF08159FE0E /* Pods_station_dev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7097B76856D5F01896F963EC /* Pods_station_dev.framework */; };
 		74E67721EFA7BF9397D52B1F /* SignInViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC59D3B5AD8926DBDD79AA1C /* SignInViewModel.swift */; };
+		7876409C275FD7CC0060EC1D /* PresentationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7876409B275FD7CC0060EC1D /* PresentationConstants.swift */; };
+		7876409E275FD88F0060EC1D /* AppAssemblyConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7876409D275FD88F0060EC1D /* AppAssemblyConstants.swift */; };
 		898D45D0BF0ABBCB2E68FBE9 /* ShareInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392F0E992BEAA3382C2CF709 /* ShareInitializer.swift */; };
 		8A37F49EA3B84BB415491B03 /* SignInModuleOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3006A5FB2173EC6AA2728D /* SignInModuleOutput.swift */; };
 		A9020042244E14F8001882C3 /* ChartFilterOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9020041244E14F8001882C3 /* ChartFilterOperation.swift */; };
@@ -1376,6 +1378,8 @@
 		6AE2284D927021C0BEA560B0 /* ShareModuleInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareModuleInput.swift; sourceTree = "<group>"; };
 		6F0552F1D17F403B7DE508B5 /* SignInRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SignInRouter.swift; sourceTree = "<group>"; };
 		7097B76856D5F01896F963EC /* Pods_station_dev.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_station_dev.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7876409B275FD7CC0060EC1D /* PresentationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationConstants.swift; sourceTree = "<group>"; };
+		7876409D275FD88F0060EC1D /* AppAssemblyConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAssemblyConstants.swift; sourceTree = "<group>"; };
 		8018B7836CF8C748718825DD /* Pods_station.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_station.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		85B8587156E1062D613B8960 /* SignInInitializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SignInInitializer.swift; sourceTree = "<group>"; };
 		85F06A44D8D006FBFB90ABE0 /* Pods-station_dev.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-station_dev.release.xcconfig"; path = "Target Support Files/Pods-station_dev/Pods-station_dev.release.xcconfig"; sourceTree = "<group>"; };
@@ -1687,6 +1691,7 @@
 				A9FC78E7257966EF00F94604 /* UniversalLinks */,
 				0E1C1DA722B387A00032F6CA /* AppAssembly.swift */,
 				64333D2820B0C45900CDF4B6 /* AppDelegate.swift */,
+				7876409D275FD88F0060EC1D /* AppAssemblyConstants.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -1927,6 +1932,7 @@
 			children = (
 				0E1C1DBD22B3921E0032F6CA /* PresentationAssembly.swift */,
 				0E197C6E23C4A7D00074015B /* Presentation.plist */,
+				7876409B275FD7CC0060EC1D /* PresentationConstants.swift */,
 			);
 			path = Assembly;
 			sourceTree = "<group>";
@@ -5402,6 +5408,7 @@
 				660EB2672669278E000FD22B /* DfuNoDeviceTableViewCell.swift in Sources */,
 				0E1C1DC122B3955E0032F6CA /* ErrorPresenter.swift in Sources */,
 				0E11D226267F3100002D0686 /* RuuviVirtualError+LocalizedError.swift in Sources */,
+				7876409C275FD7CC0060EC1D /* PresentationConstants.swift in Sources */,
 				0EBAF08223200B1B0025A191 /* LanguageTableViewCell.swift in Sources */,
 				0E59583326DA337B00A99A97 /* OwnerViewInput.swift in Sources */,
 				A98D3F12256CBD600066588B /* ShareViewController.swift in Sources */,
@@ -5423,6 +5430,7 @@
 				0E09672222AE7FCF00E85F48 /* WelcomeViewController.swift in Sources */,
 				0E1C1DE222B3C25F0032F6CA /* CardsRouterInput.swift in Sources */,
 				0E197C7923C5CCBC0074015B /* InfoProviderImpl.swift in Sources */,
+				7876409E275FD88F0060EC1D /* AppAssemblyConstants.swift in Sources */,
 				0EEB215622B8FD590015F9E0 /* WelcomeInitializer.swift in Sources */,
 				A9646466247BAE6B0001D55D /* AdvancedViewInput.swift in Sources */,
 				0EB8ED36268F685500C6B0FA /* URLSession+downloadTaskPublisher.swift in Sources */,

--- a/station/Classes/Application/AppAssembly.swift
+++ b/station/Classes/Application/AppAssembly.swift
@@ -12,7 +12,6 @@ import RuuviDFU
 import RuuviMigration
 import RuuviPersistence
 import RuuviReactor
-import SwinjectPropertyLoader
 import RuuviCloud
 import RuuviUser
 import RuuviDaemon
@@ -322,18 +321,16 @@ private final class PersistenceAssembly: Assembly {
 
 private final class NetworkingAssembly: Assembly {
     func assemble(container: Container) {
-        let config = PlistPropertyLoader(bundle: .main, name: "Networking")
-        try! container.applyPropertyLoader(config)
 
         container.register(OpenWeatherMapAPI.self) { r in
-            let apiKey: String = r.property("Open Weather Map API Key")!
+            let apiKey: String = AppAssemblyConstants.openWeatherMapApiKey
             let api = OpenWeatherMapAPIURLSession(apiKey: apiKey)
             return api
         }
 
         container.register(RuuviCloud.self) { r in
             let user = r.resolve(RuuviUser.self)!
-            let baseUrlString: String = r.property("Ruuvi Cloud URL")!
+            let baseUrlString: String = AppAssemblyConstants.ruuviCloudUrl
             let baseUrl = URL(string: baseUrlString)!
             let cloud = r.resolve(RuuviCloudFactory.self)!.create(
                 baseUrl: baseUrl,

--- a/station/Classes/Application/AppAssemblyConstants.swift
+++ b/station/Classes/Application/AppAssemblyConstants.swift
@@ -1,0 +1,23 @@
+//
+//  AppAssemblyConstants.swift
+//  station
+//
+//  Created by Iiro Alhonen on 07.12.21.
+//  Copyright © 2021 Ruuvi Innovations Oy. BSD-3-Clause.
+//
+
+import Foundation
+
+struct Networking: Codable {
+    var OpenWeatherMapAPIKey: String
+    var RuuviCloudURL: String
+}
+
+final class AppAssemblyConstants {
+    static let networkingPath = Bundle.main.path(forResource: "Networking", ofType: "plist")!
+    static let xml = FileManager.default.contents(atPath: networkingPath)!
+    static let networkingPlist = try! PropertyListDecoder().decode(Networking.self, from: xml)
+    
+    static let openWeatherMapApiKey = networkingPlist.OpenWeatherMapAPIKey
+    static let ruuviCloudUrl = networkingPlist.RuuviCloudURL
+}

--- a/station/Classes/Presentation/Assembly/Presentation.plist
+++ b/station/Classes/Presentation/Assembly/Presentation.plist
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Feedback Email</key>
+	<key>FeedbackEmail</key>
 	<string>contact@ruuvi.com</string>
-	<key>Feedback Subject</key>
+	<key>FeedbackSubject</key>
 	<string>Ruuvi Station iOS Feedback</string>
 </dict>
 </plist>

--- a/station/Classes/Presentation/Assembly/PresentationAssembly.swift
+++ b/station/Classes/Presentation/Assembly/PresentationAssembly.swift
@@ -1,12 +1,9 @@
 import Swinject
-import SwinjectPropertyLoader
 import RuuviCore
+import Foundation
 
 class PresentationAssembly: Assembly {
     func assemble(container: Container) {
-
-        let config = PlistPropertyLoader(bundle: .main, name: "Presentation")
-        try! container.applyPropertyLoader(config)
 
         container.register(ActivityPresenter.self) { _ in
             let presenter = ActivityPresenterRuuviLogo()

--- a/station/Classes/Presentation/Assembly/PresentationConstants.swift
+++ b/station/Classes/Presentation/Assembly/PresentationConstants.swift
@@ -1,0 +1,25 @@
+//
+//  PresentationConstants.swift
+//  station
+//
+//  Created by Iiro Alhonen on 07.12.21.
+//  Copyright © 2021 Ruuvi Innovations Oy. BSD-3-Clause.
+//
+
+import Foundation
+
+struct Presentation: Codable {
+    var FeedbackEmail: String
+    var FeedbackSubject: String
+}
+
+final class PresentationConstants {
+    
+    static let presentationPath = Bundle.main.path(forResource: "Presentation", ofType: "plist")!
+    static let xml = FileManager.default.contents(atPath: presentationPath)!
+    static let presentationPlist = try! PropertyListDecoder().decode(Presentation.self, from: xml)
+
+    static let feedbackEmail = presentationPlist.FeedbackEmail
+    static let feedbackSubject = presentationPlist.FeedbackSubject
+    
+}

--- a/station/Classes/Presentation/Modules/Dashboard/Cards/Assembly/Scroll/CardsScrollConfigurator.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Cards/Assembly/Scroll/CardsScrollConfigurator.swift
@@ -34,8 +34,8 @@ class CardsScrollConfigurator {
         presenter.alertService = r.resolve(RuuviServiceAlert.self)
         presenter.alertHandler = r.resolve(RuuviNotifier.self)
         presenter.mailComposerPresenter = r.resolve(MailComposerPresenter.self)
-        presenter.feedbackEmail = r.property("Feedback Email")!
-        presenter.feedbackSubject = r.property("Feedback Subject")!
+        presenter.feedbackEmail = PresentationConstants.feedbackEmail
+        presenter.feedbackSubject = PresentationConstants.feedbackSubject
         presenter.infoProvider = r.resolve(InfoProvider.self)
         presenter.ruuviReactor = r.resolve(RuuviReactor.self)
         presenter.ruuviStorage = r.resolve(RuuviStorage.self)

--- a/station/Classes/Presentation/Modules/Dashboard/Charts/Assembly/Scroll/TagChartsScrollConfigurator.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/Assembly/Scroll/TagChartsScrollConfigurator.swift
@@ -31,8 +31,8 @@ class TagChartsScrollConfigurator {
         presenter.alertHandler = r.resolve(RuuviNotifier.self)
         presenter.foreground = r.resolve(BTForeground.self)
         presenter.background = r.resolve(BTBackground.self)
-        presenter.feedbackEmail = r.property("Feedback Email")!
-        presenter.feedbackSubject = r.property("Feedback Subject")!
+        presenter.feedbackEmail = PresentationConstants.feedbackEmail
+        presenter.feedbackSubject = PresentationConstants.feedbackSubject
         presenter.infoProvider = r.resolve(InfoProvider.self)
         presenter.interactor = interactor
         presenter.ruuviSensorPropertiesService = r.resolve(RuuviServiceSensorProperties.self)

--- a/station/Resources/Plists/Networking.plist
+++ b/station/Resources/Plists/Networking.plist
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Open Weather Map API Key</key>
+	<key>OpenWeatherMapAPIKey</key>
 	<string>{ set your API key here }</string>
-	<key>Ruuvi Cloud URL</key>
+	<key>RuuviCloudURL</key>
 	<string>https://network.ruuvi.com</string>
 </dict>
 </plist>


### PR DESCRIPTION
Remove the pod for SwinjectPropertyLoader and fetch required values manually from the plist.

Requires changes to com.ruuvi.station.ios.keystore.git repo and should not be merged before those changes are merged.