### PR TITLE
Comment out removal of readme artifact in fastlane.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,7 @@ def remove_artifacts
   begin
       sh("rm", "-rf", "com.ruuvi.station.ios.keystore")
       sh("rm", "report.xml")
-      sh("rm", "README.md")
+      # sh("rm", "README.md")
    rescue => ex
      UI.error(ex)
    end


### PR DESCRIPTION
In the last two builds there has been no readme file to remove, so the build has crashed. This MR comments out the removal of readme, so builds can finish and can be tested.