### PR TITLE
Issue #581 fix

### DIFF
--- a/Packages/RuuviService/Sources/RuuviServiceMeasurement/RuuviServiceMeasurementImpl.swift
+++ b/Packages/RuuviService/Sources/RuuviServiceMeasurement/RuuviServiceMeasurementImpl.swift
@@ -259,7 +259,11 @@ extension RuuviServiceMeasurementImpl {
     }
 
     public func humidityOffsetCorrectionString(for humidity: Double) -> String {
-        return "\((humidityOffsetCorrection(for: humidity) * 100).round(to: 2)) \(percentString)"
+        return humidityFormatter.string(
+            from: Humidity(value: humidityOffsetCorrection(for: humidity),
+                           unit: UnitHumidity.relative(temperature: Temperature(value: 0.0,
+                                                                                unit: UnitTemperature.celsius)))
+        )
     }
 
     public func pressureOffsetCorrection(for pressure: Double) -> Double {


### PR DESCRIPTION
humidityFormatter used for humidityOffsetCorrectionString to get the value localized.

Not sure if the calibration unit should change with settings, the raised issue concerned only localization of the numeric value and the humidity calibration value edit dialog is also using just relative humidity.

