### PR TITLE
fix: Set 2 seconds delay before showing the buttons

### DIFF
--- a/station/Classes/Presentation/Modules/Dashboard/Charts/Presenter/TagChartsPresenter.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/Presenter/TagChartsPresenter.swift
@@ -175,6 +175,9 @@ extension TagChartsPresenter: TagChartsViewOutput {
         let serviceTimeout: TimeInterval = settings.serviceTimeout
         let op = interactor.syncRecords { [weak self] progress in
             DispatchQueue.main.async { [weak self] in
+                guard let syncing =  self?.isSyncing, syncing else {
+                    return
+                }
                 self?.view.setSync(progress: progress, for: viewModel)
             }
         }
@@ -189,12 +192,9 @@ extension TagChartsPresenter: TagChartsViewOutput {
                 self?.view.showFailedToServeIn(serviceTimeout: serviceTimeout)
             } else {
                 self?.errorPresenter.present(error: error)
+                
             }
-        }, completion: {
-            DispatchQueue.main.async { [weak self] in
-                self?.view.setSync(progress: nil, for: viewModel)
-            }
-        })
+        }, completion: nil)
     }
 
     func viewDidConfirmToClear(for viewModel: TagChartsViewModel) {

--- a/station/Classes/Presentation/Modules/Dashboard/Charts/View/Scroll/TagChartsScrollViewController.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/View/Scroll/TagChartsScrollViewController.swift
@@ -116,14 +116,19 @@ extension TagChartsScrollViewController: TagChartsViewInput {
             case .disconnecting:
                 syncStatusLabel.text = "TagCharts.Status.Disconnecting".localized()
             case .success:
+                ///Show success message
                 syncStatusLabel.text = "TagCharts.Status.Success".localized()
+                /// Hide success message and show buttons after two seconds
+                showUtilButtons()
             case .failure:
+                ///Show success message
                 syncStatusLabel.text = "TagCharts.Status.Error".localized()
+                /// Hide success message and show buttons after two seconds
+                showUtilButtons()
             }
         } else {
-            syncStatusLabel.isHidden = true
-            syncButton.isHidden = false
-            clearButton.isHidden = false
+            /// Show buttons after two seconds if there's an unexpected error
+            showUtilButtons()
         }
     }
 
@@ -339,5 +344,15 @@ extension TagChartsScrollViewController {
         } else {
             alertImageView.image = nil
         }
+    }
+    
+    /// This method helps present the clear and sync button after a successful or failed operation.
+    /// However, the visibility changes after two seconds to make sure user have a noticeable time to see the operation response
+    private func showUtilButtons() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2), execute: { [weak self] in
+            self?.syncStatusLabel.isHidden = true
+            self?.syncButton.isHidden = false
+            self?.clearButton.isHidden = false
+        })
     }
 }


### PR DESCRIPTION
After a successful or failed operation, the message is shown and a static 2 seconds delay added in between message showing and buttons showing back to give users a noticeable period to read/view the operation message.

The completion handler is not absolutely necessary in this scenario. Hence, it's not utilized as that was causing the conflict with syncRecords method above which raised issue #657