### PR TITLE
fix: Remove sensor settings check when presenting chart #694

### DIFF
--- a/Packages/RuuviService/Sources/RuuviServiceCloudSync/RuuviServiceCloudSyncImpl.swift
+++ b/Packages/RuuviService/Sources/RuuviServiceCloudSync/RuuviServiceCloudSyncImpl.swift
@@ -183,7 +183,12 @@ public final class RuuviServiceCloudSyncImpl: RuuviServiceCloudSync {
                                 return self.ruuviPool.update(unclaimed)
                             } else {
                                 // If there is a local sensor which is claimed and deleted from the cloud, delete it from local storage
-                                return self.ruuviPool.delete(localSensor)
+                                // Otherwise keep it stored
+                                if localSensor.isCloud {
+                                    return self.ruuviPool.delete(localSensor)
+                                } else {
+                                    return nil
+                                }
                             }
                         }
                     })

--- a/station/Classes/Presentation/Modules/Dashboard/Chart/Presenter/TagChartModuleInput.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Chart/Presenter/TagChartModuleInput.swift
@@ -3,7 +3,7 @@ import RuuviOntology
 
 protocol TagChartModuleInput: AnyObject {
     var chartView: TagChartView { get }
-    func configure(_ viewModel: TagChartViewModel, sensorSettings: SensorSettings, output: TagChartModuleOutput, luid: LocalIdentifier?)
+    func configure(_ viewModel: TagChartViewModel, sensorSettings: SensorSettings?, output: TagChartModuleOutput, luid: LocalIdentifier?)
     func insertMeasurements(_ newValues: [RuuviMeasurement])
     func removeMeasurements(_ oldValues: [RuuviMeasurement])
     func setProgress(_ value: Float)

--- a/station/Classes/Presentation/Modules/Dashboard/Chart/Presenter/TagChartPresenter.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Chart/Presenter/TagChartPresenter.swift
@@ -14,7 +14,7 @@ class TagChartPresenter: NSObject {
         }
     }
     weak var ouptut: TagChartModuleOutput!
-    private var sensorSettings: SensorSettings!
+    private var sensorSettings: SensorSettings?
     var measurementService: RuuviServiceMeasurement! {
         didSet {
             measurementService.add(self)
@@ -68,7 +68,7 @@ extension TagChartPresenter: TagChartModuleInput {
         self.viewModel = viewModel
     }
 
-    func configure(_ viewModel: TagChartViewModel, sensorSettings: SensorSettings, output: TagChartModuleOutput, luid: LocalIdentifier?) {
+    func configure(_ viewModel: TagChartViewModel, sensorSettings: SensorSettings?, output: TagChartModuleOutput, luid: LocalIdentifier?) {
         configureViewModel(viewModel)
         self.ouptut = output
         self.sensorSettings = sensorSettings

--- a/station/Classes/Presentation/Modules/Dashboard/Charts/Interactor/TagChartsInteractor.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/Interactor/TagChartsInteractor.swift
@@ -54,9 +54,6 @@ class TagChartsInteractor {
         MeasurementType.chartsCases.forEach({
             let viewModel = TagChartViewModel(type: $0)
             let module = TagChartAssembler.createModule()
-            guard let sensorSettings = sensorSettings else {
-                return
-            }
             module.configure(viewModel, sensorSettings: sensorSettings, output: self, luid: ruuviTagSensor.luid)
             chartModules.append(module)
         })


### PR DESCRIPTION
Do not remove local sensors when sync from cloud. Only remove locally stored sensors which are deleted from cloud.

Remove sensor settings check before showing chart. That check was preventing charts being shown for the local sensors without settings property.