### PR TITLE
fix: Make tag removable in connecting state #599 #403

### DIFF
--- a/station/Classes/Presentation/Modules/TagSettings/Presenter/TagSettingsPresenter.swift
+++ b/station/Classes/Presentation/Modules/TagSettings/Presenter/TagSettingsPresenter.swift
@@ -184,12 +184,6 @@ extension TagSettingsPresenter: TagSettingsViewOutput {
     }
 
     func viewDidConfirmTagRemoval() {
-        if let isConnected = viewModel.isConnected.value,
-           let keepConnection = viewModel.keepConnection.value,
-           !isConnected && keepConnection {
-            errorPresenter.present(error: RUError.expected(.failedToDeleteTag))
-            return
-        }
         ruuviOwnershipService.remove(sensor: ruuviTag).on(success: { [weak self] _ in
             guard let sSelf = self else { return }
             sSelf.viewModel.reset()


### PR DESCRIPTION
Tags are now removable when the tag is not in Bluetooth range and in connecting state.