### PR TITLE
fix: Show timeout error after failed to sync #657 #643

### DIFF
--- a/station/Classes/Presentation/Modules/Dashboard/Charts/Presenter/TagChartsPresenter.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/Presenter/TagChartsPresenter.swift
@@ -192,11 +192,12 @@ extension TagChartsPresenter: TagChartsViewOutput {
             self?.view.setSync(progress: nil, for: viewModel)
             if case .btkit(.logic(.connectionTimedOut)) = error {
                 self?.view.showFailedToSyncIn(connectionTimeout: connectionTimeout)
+            } else if case .ruuviService(.btkit(.logic(.connectionTimedOut))) = error {
+                self?.view.showFailedToSyncIn(connectionTimeout: connectionTimeout)
             } else if case .btkit(.logic(.serviceTimedOut)) = error {
                 self?.view.showFailedToServeIn(serviceTimeout: serviceTimeout)
             } else {
                 self?.errorPresenter.present(error: error)
-                
             }
         }, completion: nil)
     }


### PR DESCRIPTION
The issue with showing the wrong error message is rectified.  