### PR TITLE
fix: Support default mail app #603

### DIFF
--- a/station/Classes/Application/Info/Impl/InfoProviderImpl.swift
+++ b/station/Classes/Application/Info/Impl/InfoProviderImpl.swift
@@ -89,18 +89,19 @@ class InfoProviderImpl: InfoProvider {
 
     func summary(completion: @escaping (String) -> Void) {
         var result = ""
+        result += "------------------------------------------\n"
         #if targetEnvironment(macCatalyst)
-            result += "<p>MacCatalyst</p>"
+            result += "MacCatalyst"
         #else
-            result += "<p>Device: " + deviceModel + "</p>"
+            result += "Device: " + deviceModel + "\n"
         #endif
-        result += "<p>OS: " + systemName + " " + systemVersion + "</p>"
-        result += "<p>App: " + appName + " " + appVersion + "</p>"
-        result += "<p>" + locationPermission + "</p>"
-        result += "<p>" + photoLibraryPermission + "</p>"
-        result += "<p>" + cameraPermission + "</p>"
+        result += "OS: " + systemName + " " + systemVersion + "\n"
+        result += "App: " + appName + " " + appVersion + "\n"
+        result += locationPermission + "\n"
+        result += photoLibraryPermission + "\n"
+        result += cameraPermission + "\n"
 
-        result += "<p>Notifications: "
+        result += "Notifications: "
         UNUserNotificationCenter.current().getNotificationSettings { (settings) in
             DispatchQueue.main.async {
                 switch settings.authorizationStatus {
@@ -117,7 +118,7 @@ class InfoProviderImpl: InfoProvider {
                 @unknown default:
                     result += "unknown"
                 }
-                result += "</p>"
+                result += "\n------------------------------------------\n"
                 completion(result)
             }
         }

--- a/station/Classes/Presentation/Modules/Dashboard/Cards/Presenter/CardsPresenter.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Cards/Presenter/CardsPresenter.swift
@@ -261,7 +261,7 @@ extension CardsPresenter: MenuModuleOutput {
             guard let sSelf = self else { return }
             sSelf.mailComposerPresenter.present(email: sSelf.feedbackEmail,
                                                 subject: sSelf.feedbackSubject,
-                                                body: "<br><br>" + summary)
+                                                body: "\n\n" + summary)
         }
     }
     func menu(module: MenuModuleInput, didSelectSignIn sender: Any?) {

--- a/station/Classes/Presentation/Presenters/MailComposer/MessageUI/MailComposerPresenterMessageUI.swift
+++ b/station/Classes/Presentation/Presenters/MailComposer/MessageUI/MailComposerPresenterMessageUI.swift
@@ -7,15 +7,24 @@ class MailComposerPresenterMessageUI: NSObject, MailComposerPresenter {
 
     func present(email: String, subject: String, body: String?) {
         guard let viewController = UIApplication.shared.topViewController() else { return }
+        // If default iOS Mail app is configured, open the mail composer
+        // Otherwise open the default email client set by the user followed by checking whether gmail app
+        let emailRecipient = String(format: "App Feedback <%@>".localized(), email)
         if MFMailComposeViewController.canSendMail() {
             let mail = MFMailComposeViewController()
             mail.mailComposeDelegate = self
             mail.setSubject(subject)
             if let body = body {
-                mail.setMessageBody(body, isHTML: true)
+                mail.setMessageBody(body, isHTML: false)
             }
-            mail.setToRecipients([String(format: "App Feedback <%@>".localized(), email)])
+            mail.setToRecipients([emailRecipient])
             viewController.present(mail, animated: true)
+        } else if let emailURL = generateEmailURL(email: emailRecipient, subject: subject, body: body) {
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(emailURL)
+            } else {
+                UIApplication.shared.openURL(emailURL)
+            }
         } else {
             errorPresenter.present(error: CoreError.unableToSendEmail)
         }
@@ -28,5 +37,27 @@ extension MailComposerPresenterMessageUI: MFMailComposeViewControllerDelegate {
                                didFinishWith result: MFMailComposeResult,
                                error: Error?) {
         controller.dismiss(animated: true)
+    }
+}
+
+// MARK: - Private method
+extension MailComposerPresenterMessageUI {
+    /// This method takes three arguments recipient email, subject and body.
+    /// Returns a computer email URL that opens the default email client set by the user.
+    private func generateEmailURL(email: String, subject: String, body: String?) -> URL? {
+        guard let toEncoded = email
+                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let subjectEncoded = subject
+                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            return nil
+        }
+        let bodyEncoded = body?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+
+        let defaultURL = URL(string: "mailto:\(toEncoded)?subject=\(subjectEncoded)&body=\(bodyEncoded)")
+        if let defaultURL = defaultURL, UIApplication.shared.canOpenURL(defaultURL) {
+            return defaultURL
+        } else {
+            return nil
+        }
     }
 }

--- a/station/Resources/Plists/Info.plist
+++ b/station/Resources/Plists/Info.plist
@@ -83,5 +83,11 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>https</string>
+        <string>http</string>
+        <string>mailto</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
HTML markups are replaced with regular line breaks

Open default app set by user if the default mail app is not configured