### PR TITLE
fix: Hide added sensors from discover screen #738

### DIFF
--- a/Modules/RuuviDiscover/Sources/RuuviDiscover/VMP/Presenter/DiscoverPresenter.swift
+++ b/Modules/RuuviDiscover/Sources/RuuviDiscover/VMP/Presenter/DiscoverPresenter.swift
@@ -47,7 +47,7 @@ class DiscoverPresenter: NSObject, RuuviDiscover {
     }
     private var persistedSensors: [RuuviTagSensor]! {
         didSet {
-            view?.savedRuuviTagIds = persistedSensors.map({ $0.luid?.any })
+            view?.persistedSensors = persistedSensors
         }
     }
     private var reloadTimer: Timer?

--- a/Modules/RuuviDiscover/Sources/RuuviDiscover/VMP/View/DiscoverViewInput.swift
+++ b/Modules/RuuviDiscover/Sources/RuuviDiscover/VMP/View/DiscoverViewInput.swift
@@ -6,7 +6,7 @@ import RuuviLocalization
 
 protocol DiscoverViewInput: UIViewController, Localizable {
     var ruuviTags: [DiscoverRuuviTagViewModel] { get set }
-    var savedRuuviTagIds: [AnyLocalIdentifier?] { get set }
+    var persistedSensors: [RuuviTagSensor] { get set }
     var virtualTags: [DiscoverVirtualTagViewModel] { get set }
     var savedWebTagProviders: [VirtualProvider] { get set }
     var isBluetoothEnabled: Bool { get set }

--- a/Modules/RuuviDiscover/Sources/RuuviDiscover/VMP/View/Table/DiscoverTableViewController.swift
+++ b/Modules/RuuviDiscover/Sources/RuuviDiscover/VMP/View/Table/DiscoverTableViewController.swift
@@ -52,8 +52,11 @@ class DiscoverTableViewController: UITableViewController {
     var ruuviTags: [DiscoverRuuviTagViewModel] = [DiscoverRuuviTagViewModel]() {
         didSet {
             shownRuuviTags = ruuviTags
-                .filter({ !savedRuuviTagIds.contains( $0.luid )})
-                .sorted(by: {
+                .filter({ tag in
+                    !persistedSensors.contains(where: {
+                        $0.luid?.value == tag.luid?.value || $0.macId?.value == tag.mac
+                    })
+                }).sorted(by: {
                     if let rssi0 = $0.rssi, let rssi1 = $1.rssi {
                         return rssi0 > rssi1
                     } else {
@@ -62,11 +65,14 @@ class DiscoverTableViewController: UITableViewController {
                 })
         }
     }
-    var savedRuuviTagIds: [AnyLocalIdentifier?] = [AnyLocalIdentifier?]() {
+    var persistedSensors: [RuuviTagSensor] = [RuuviTagSensor]() {
         didSet {
             shownRuuviTags = ruuviTags
-                .filter({ !savedRuuviTagIds.contains($0.luid) })
-                .sorted(by: {
+                .filter({ tag in
+                    !persistedSensors.contains(where: {
+                        $0.luid?.value == tag.luid?.value || $0.macId?.value == tag.mac
+                    })
+                }).sorted(by: {
                     if let rssi0 = $0.rssi, let rssi1 = $1.rssi {
                         return rssi0 > rssi1
                     } else {


### PR DESCRIPTION
Breaking Changes!

This commit contains changes to showing sensors on the discover page which may potentially break the working feature. Needs careful testing.

