### PR TITLE
fix: Improve gatt sync experience #1027

### DIFF
--- a/station/Classes/Presentation/Modules/Dashboard/Charts/Presenter/TagChartsPresenter.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/Presenter/TagChartsPresenter.swift
@@ -48,6 +48,8 @@ class TagChartsPresenter: NSObject, TagChartsModuleInput {
         }
     }
     private var output: TagChartsModuleOutput?
+    private var advertisementToken: ObservationToken?
+    private var heartbeatToken: ObservationToken?
     private var stateToken: ObservationToken?
     private var temperatureUnitToken: NSObjectProtocol?
     private var humidityUnitToken: NSObjectProtocol?
@@ -85,6 +87,8 @@ class TagChartsPresenter: NSObject, TagChartsModuleInput {
     }
     deinit {
         stateToken?.invalidate()
+        advertisementToken?.invalidate()
+        heartbeatToken?.invalidate()
         temperatureUnitToken?.invalidate()
         humidityUnitToken?.invalidate()
         pressureUnitToken?.invalidate()
@@ -127,13 +131,14 @@ extension TagChartsPresenter: TagChartsViewOutput {
     }
 
     func viewWillAppear() {
+        startObservingRuuviTag()
         startListeningToSettings()
         startObservingBluetoothState()
         startListeningToAlertStatus()
         tryToShowSwipeUpHint()
         restartObservingData()
         interactor.restartObservingTags()
-        handleClearSyncButtons()
+        handleClearSyncButtons(connectable: false)
         syncChartViews()
         stopGattSync()
     }
@@ -146,8 +151,8 @@ extension TagChartsPresenter: TagChartsViewOutput {
         view?.setupChartViews(chartViews: interactor.chartViews)
     }
 
-    func handleClearSyncButtons() {
-        view.handleClearSyncButtons(cloudSensor: settings.cloudModeEnabled && viewModel.isCloud.value.bound,
+    func handleClearSyncButtons(connectable: Bool) {
+        view.handleClearSyncButtons(connectable: connectable,
                                     isSyncing: interactor.isSyncingRecords())
     }
 
@@ -161,7 +166,7 @@ extension TagChartsPresenter: TagChartsViewOutput {
 
     func viewDidTriggerCards(for viewModel: TagChartsViewModel) {
         if interactor.isSyncingRecords() {
-            view.showSyncAbortAlert()
+            view.showSyncAbortAlert(dismiss: true)
         } else {
             stopRunningProcesses()
             router.dismiss()
@@ -218,7 +223,7 @@ extension TagChartsPresenter: TagChartsViewOutput {
     }
 
     func viewDidTriggerStopSync(for viewModel: TagChartsViewModel) {
-        stopGattSync()
+        view.showSyncAbortAlert(dismiss: false)
     }
 
     func viewDidTriggerClear(for viewModel: TagChartsViewModel) {
@@ -239,9 +244,13 @@ extension TagChartsPresenter: TagChartsViewOutput {
         interactor.notifyDidLocalized()
     }
 
-    func viewDidConfirmAbortSync() {
-        stopRunningProcesses()
-        router.dismiss()
+    func viewDidConfirmAbortSync(dismiss: Bool) {
+        if dismiss {
+            stopRunningProcesses()
+            router.dismiss()
+        } else {
+            stopGattSync()
+        }
     }
 }
 // MARK: - TagChartsInteractorOutput
@@ -400,6 +409,48 @@ extension TagChartsPresenter {
             .on(success: { [weak self] _ in
                 self?.view.setSyncProgressViewHidden()
             })
+    }
+
+    private func startObservingRuuviTag() {
+        advertisementToken?.invalidate()
+        heartbeatToken?.invalidate()
+        guard let luid = ruuviTag.luid else {
+            return
+        }
+        advertisementToken = foreground.observe(self, uuid: luid.value, closure: { [weak self] (_, device) in
+            if let tag = device.ruuvi?.tag {
+                self?.sync(device: tag, source: .advertisement)
+            }
+        })
+
+        heartbeatToken = background.observe(self, uuid: luid.value, closure: { [weak self] (_, device) in
+            if let tag = device.ruuvi?.tag {
+                self?.sync(device: tag, source: .heartbeat)
+            }
+        })
+    }
+
+    private func sync(device: RuuviTag,
+                      source: RuuviTagSensorRecordSource) {
+        if device.isConnected {
+            if source == .heartbeat {
+                if viewModel.isConnectable.value != device.isConnectable {
+                    viewModel.isConnectable.value = device.isConnectable
+                }
+            } else {
+                if viewModel.isConnectable.value != device.isConnected {
+                    viewModel.isConnectable.value = device.isConnected
+                }
+            }
+        } else {
+            if viewModel.isConnectable.value != device.isConnectable {
+                viewModel.isConnectable.value = device.isConnectable
+            }
+        }
+
+        let connectable = viewModel.isConnectable.value.bound &&
+                          !settings.cloudModeEnabled
+        handleClearSyncButtons(connectable: connectable)
     }
 
     private func restartObservingData() {
@@ -613,7 +664,12 @@ extension TagChartsPresenter {
                          object: nil,
                          queue: .main,
                          using: { [weak self] _ in
-                self?.handleClearSyncButtons()
+                guard let sSelf = self else {
+                    return
+                }
+                let connectable = sSelf.viewModel.isConnectable.value.bound &&
+                                  !sSelf.settings.cloudModeEnabled
+                sSelf.handleClearSyncButtons(connectable: connectable)
             })
     }
 
@@ -623,6 +679,8 @@ extension TagChartsPresenter {
     }
 
     private func stopRunningProcesses() {
+        advertisementToken?.invalidate()
+        heartbeatToken?.invalidate()
         stopObservingBluetoothState()
         interactor.stopObservingTags()
         interactor.stopObservingRuuviTagsData()

--- a/station/Classes/Presentation/Modules/Dashboard/Charts/View/Scroll/TagChartsScrollViewController.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/View/Scroll/TagChartsScrollViewController.swift
@@ -78,18 +78,18 @@ extension TagChartsScrollViewController: TagChartsViewInput {
 
     /// This method requires more context
     /// 1: Clear and Sync button should not be visible and
-    /// the status should be visible is a sync progress is already running in the background
+    /// the status should be visible if a sync progress is already running in the background
     /// 2: Clear and Sync button should be hidden for shared sensors
     /// 3: The only case these buttons are shown are when the last stored data is from the cloud
     /// no sync process running in the background
-    func handleClearSyncButtons(cloudSensor: Bool, isSyncing: Bool) {
+    func handleClearSyncButtons(connectable: Bool, isSyncing: Bool) {
         if isSyncing {
             hideUtilButtons()
             syncStatusLabel.isHidden = false
             syncStatusLabel.text = "TagCharts.Status.Serving".localized()
             return
         }
-        if cloudSensor {
+        if !connectable {
             hideUtilButtons()
             syncStatusLabel.isHidden = true
         } else {
@@ -187,14 +187,15 @@ extension TagChartsScrollViewController: TagChartsViewInput {
         gestureInstructor.show(.swipeUp, after: 0.1)
     }
 
-    func showSyncAbortAlert() {
+    func showSyncAbortAlert(dismiss: Bool) {
         let title = "TagCharts.DeleteHistoryConfirmationDialog.title".localized()
-        let message = "TagSettings.AbortSync.Alert.message".localized()
+        let message = dismiss ? "TagCharts.Dismiss.Alert.message".localized() :
+                                "TagCharts.AbortSync.Alert.message".localized()
         let alertVC = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alertVC.addAction(UIAlertAction(title: "OK".localized(), style: .cancel, handler: nil))
-        let actionTitle = "TagSettings.AbortSync.Button.title".localized()
+        let actionTitle = "TagCharts.AbortSync.Button.title".localized()
         alertVC.addAction(UIAlertAction(title: actionTitle, style: .destructive, handler: { [weak self] _ in
-            self?.output.viewDidConfirmAbortSync()
+            self?.output.viewDidConfirmAbortSync(dismiss: dismiss)
         }))
         present(alertVC, animated: true)
     }

--- a/station/Classes/Presentation/Modules/Dashboard/Charts/View/TagChartsViewInput.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/View/TagChartsViewInput.swift
@@ -7,12 +7,12 @@ protocol TagChartsViewInput: ViewInput {
     var viewIsVisible: Bool { get }
     func setupChartViews(chartViews: [TagChartView])
     func showBluetoothDisabled()
-    func handleClearSyncButtons(cloudSensor: Bool, isSyncing: Bool)
+    func handleClearSyncButtons(connectable: Bool, isSyncing: Bool)
     func showClearConfirmationDialog(for viewModel: TagChartsViewModel)
     func setSync(progress: BTServiceProgress?, for viewModel: TagChartsViewModel)
     func setSyncProgressViewHidden()
     func showFailedToSyncIn(connectionTimeout: TimeInterval)
     func showFailedToServeIn(serviceTimeout: TimeInterval)
     func showSwipeUpInstruction()
-    func showSyncAbortAlert()
+    func showSyncAbortAlert(dismiss: Bool)
 }

--- a/station/Classes/Presentation/Modules/Dashboard/Charts/View/TagChartsViewModel.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/View/TagChartsViewModel.swift
@@ -14,7 +14,7 @@ struct TagChartsViewModel {
     var mac: Observable<String?> = Observable<String?>()
     var name: Observable<String?> = Observable<String?>()
     var background: Observable<UIImage?> = Observable<UIImage?>()
-    var isConnectable: Observable<Bool?> = Observable<Bool?>()
+    var isConnectable: Observable<Bool?> = Observable<Bool?>(false)
     var isCloud: Observable<Bool?> = Observable<Bool?>()
     var alertState: Observable<AlertState?> = Observable<AlertState?>()
     var isConnected: Observable<Bool?> = Observable<Bool?>()

--- a/station/Classes/Presentation/Modules/Dashboard/Charts/View/TagChartsViewOutput.swift
+++ b/station/Classes/Presentation/Modules/Dashboard/Charts/View/TagChartsViewOutput.swift
@@ -14,5 +14,5 @@ protocol TagChartsViewOutput {
     func viewDidTriggerClear(for viewModel: TagChartsViewModel)
     func viewDidConfirmToClear(for viewModel: TagChartsViewModel)
     func viewDidLocalized()
-    func viewDidConfirmAbortSync()
+    func viewDidConfirmAbortSync(dismiss: Bool)
 }

--- a/station/Resources/Strings/de.lproj/Localizable.strings
+++ b/station/Resources/Strings/de.lproj/Localizable.strings
@@ -149,8 +149,9 @@ If you cannot see the Language option in the settings, make sure that you have a
 "TagSettings.UpdateFirmware.Alert.title" = "RAWv2-Modus ist erforderlich";
 "TagSettings.UpdateFirmware.Alert.message" = "Um fehlende Werte anzuzeigen:\n Wenn Sie die neueste Firmware verwenden, stellen Sie den RAWv2-Modus ein, indem Sie auf einem Sensor \"B\" drücken.\ oder aktualisieren Sie Ihren Sensor mit der neuesten Firmware.";
 "TagSettings.UpdateFirmware.Alert.Buttons.LearnMore.title" = "Mehr erfahren";
-"TagSettings.AbortSync.Alert.message" = "History downloading via Bluetooth connection is in progress. Please wait.";
-"TagSettings.AbortSync.Button.title" = "Abort downloading";
+"TagCharts.Dismiss.Alert.message" = "History downloading via Bluetooth connection is in progress. Please wait.";
+"TagCharts.AbortSync.Alert.message" = "Sometimes history downloading is slow due to the Bluetooth connectivity. Please wait a moment.";
+"TagCharts.AbortSync.Button.title" = "Abort downloading";
 "TagSettings.EmptyValue.sign" = "-";
 "TagSettings.HumidityIsClipped.Alert.title" = "Luftfeuchtigkeit wird angepasst";
 "TagSettings.HumidityIsClipped.Alert.message" = "Der Feuchtigkeitswert ist nach der Kalibrierung größer als 100,0 %. Dieser Wert ist nicht sinnvoll, daher wird der Wert auf 100,0 % angepasst.";

--- a/station/Resources/Strings/en.lproj/Localizable.strings
+++ b/station/Resources/Strings/en.lproj/Localizable.strings
@@ -149,8 +149,9 @@ If you cannot see the Language option in the settings, make sure that you have a
 "TagSettings.UpdateFirmware.Alert.title" = "RAWv2 mode is required";
 "TagSettings.UpdateFirmware.Alert.message" = "In order to see missing values:\nIf you are using the latest firmware, set RAWv2 mode by pressing \"B\" on a sensor.\nOr update your sensor with the latest firmware.";
 "TagSettings.UpdateFirmware.Alert.Buttons.LearnMore.title" = "Learn more";
-"TagSettings.AbortSync.Alert.message" = "History downloading via Bluetooth connection is in progress. Please wait.";
-"TagSettings.AbortSync.Button.title" = "Abort downloading";
+"TagCharts.Dismiss.Alert.message" = "History downloading via Bluetooth connection is in progress. Please wait.";
+"TagCharts.AbortSync.Alert.message" = "Sometimes history downloading is slow due to the Bluetooth connectivity. Please wait a moment.";
+"TagCharts.AbortSync.Button.title" = "Abort downloading";
 "TagSettings.EmptyValue.sign" = "-";
 "TagSettings.HumidityIsClipped.Alert.title" = "Humidity is adjusted";
 "TagSettings.HumidityIsClipped.Alert.message" = "Humidity value is greater than 100.0% after calibration. This value doesn't make sense, so the value is adjusted to 100.0%.";

--- a/station/Resources/Strings/fi.lproj/Localizable.strings
+++ b/station/Resources/Strings/fi.lproj/Localizable.strings
@@ -149,8 +149,9 @@ Mikäli et näe Kieli-valintaa asetuksissa, varmista, että sinulla on vähintä
 "TagSettings.UpdateFirmware.Alert.title" = "RAWv2-formaatti vaaditaan";
 "TagSettings.UpdateFirmware.Alert.message" = "Puuttuvat arvot voidaan näyttää ainoastaan uudemmalla laiteohjelmistoversiolla.";
 "TagSettings.UpdateFirmware.Alert.Buttons.LearnMore.title" = "Lue lisää";
-"TagSettings.AbortSync.Alert.message" = "Historian lataaminen Bluetooth-yhteydellä on käynnissä. Odota hetki.";
-"TagSettings.AbortSync.Button.title" = "Peruuta lataaminen";
+"TagCharts.Dismiss.Alert.message" = "Historian lataaminen Bluetooth-yhteydellä on käynnissä. Odota hetki.";
+"TagCharts.AbortSync.Alert.message" = "Historian lataaminen voi kestää pitkään Bluetooth-yhteyden laadusta riippuen. Odota hetki.";
+"TagCharts.AbortSync.Button.title" = "Peruuta lataaminen";
 "TagSettings.EmptyValue.sign" = "-";
 "TagSettings.HumidityIsClipped.Alert.title" = "Kosteus on säädetty";
 "TagSettings.HumidityIsClipped.Alert.message" = "Kalibroinnin jälkeinen kosteusarvo on suurempi kuin 100%. Tämä ei käy järkeen, joten maksimiarvona näytetään 100%.";

--- a/station/Resources/Strings/fr.lproj/Localizable.strings
+++ b/station/Resources/Strings/fr.lproj/Localizable.strings
@@ -149,8 +149,9 @@ If you cannot see the Language option in the settings, make sure that you have a
 "TagSettings.UpdateFirmware.Alert.title" = "Format RAWv2 nécessaire";
 "TagSettings.UpdateFirmware.Alert.message" = "L'affichage des informations manquantes n'est possible qu'avec la nouvelle version système.";
 "TagSettings.UpdateFirmware.Alert.Buttons.LearnMore.title" = "Plus d'infos";
-"TagSettings.AbortSync.Alert.message" = "History downloading via Bluetooth connection is in progress. Please wait.";
-"TagSettings.AbortSync.Button.title" = "Abort downloading";
+"TagCharts.Dismiss.Alert.message" = "History downloading via Bluetooth connection is in progress. Please wait.";
+"TagCharts.AbortSync.Alert.message" = "Sometimes history downloading is slow due to the Bluetooth connectivity. Please wait a moment.";
+"TagCharts.AbortSync.Button.title" = "Abort downloading";
 "TagSettings.EmptyValue.sign" = "-";
 "TagSettings.HumidityIsClipped.Alert.title" = "L'hygromètre est calibré";
 "TagSettings.HumidityIsClipped.Alert.message" = "L'humidité est supérieure à 100.0% après calibrage. Cela n'a pas de sens, donc la valeur max affichée est 100%.";

--- a/station/Resources/Strings/ru.lproj/Localizable.strings
+++ b/station/Resources/Strings/ru.lproj/Localizable.strings
@@ -149,8 +149,9 @@ If you cannot see the Language option in the settings, make sure that you have a
 "TagSettings.UpdateFirmware.Alert.title" = "Необходим Режим RAWv2";
 "TagSettings.UpdateFirmware.Alert.message" = "Для того, чтобы увидеть отсутствующие значения:\nЕсли вы используете последнюю прошивку, включите RAWv2 режим нажатием кнопки \"B\" на вашем сенсоре.\nИли обновите ваш сенсор с последней прошивкой.";
 "TagSettings.UpdateFirmware.Alert.Buttons.LearnMore.title" = "Узнать больше";
-"TagSettings.AbortSync.Alert.message" = "History downloading via Bluetooth connection is in progress. Please wait.";
-"TagSettings.AbortSync.Button.title" = "Abort downloading";
+"TagCharts.Dismiss.Alert.message" = "History downloading via Bluetooth connection is in progress. Please wait.";
+"TagCharts.AbortSync.Alert.message" = "Sometimes history downloading is slow due to the Bluetooth connectivity. Please wait a moment.";
+"TagCharts.AbortSync.Button.title" = "Abort downloading";
 "TagSettings.EmptyValue.sign" = "-";
 "TagSettings.HumidityIsClipped.Alert.title" = "Датчик влажности откалиброван";
 "TagSettings.HumidityIsClipped.Alert.message" = "Значение относительной влажности больше 100% после калибровки. Это значение не имеет смысла, поэтому значение откалибровано до 100%.";

--- a/station/Resources/Strings/sv.lproj/Localizable.strings
+++ b/station/Resources/Strings/sv.lproj/Localizable.strings
@@ -149,8 +149,9 @@ Om du inte kan se språkalternativet i inställningarna, se till att du har lagt
 "TagSettings.UpdateFirmware.Alert.title" = "RAWv2-format krävs";
 "TagSettings.UpdateFirmware.Alert.message" = "Värden som saknas kan bara visas i nyare enhetsmjukvara med RAWv2-format.";
 "TagSettings.UpdateFirmware.Alert.Buttons.LearnMore.title" = "Läs mer";
-"TagSettings.AbortSync.Alert.message" = "History downloading via Bluetooth connection is in progress. Please wait.";
-"TagSettings.AbortSync.Button.title" = "Abort downloading";
+"TagCharts.Dismiss.Alert.message" = "Nedladdning av historik via Bluetooth pågår. Vänta.";
+"TagCharts.AbortSync.Alert.message" = "Sometimes history downloading is slow due to the Bluetooth connectivity. Please wait a moment.";
+"TagCharts.AbortSync.Button.title" = "Avbryt nedladdning";
 "TagSettings.EmptyValue.sign" = "-";
 "TagSettings.HumidityIsClipped.Alert.title" = "Luftfuktigheten är justerad";
 "TagSettings.HumidityIsClipped.Alert.message" = "Fuktighetsvärdet efter kalibreringen är större än 100%. Detta är inte rimligt, så det maximala värdet visas som 100%.";


### PR DESCRIPTION
- Show confirmation alert when user tries to cancel an ongoing gatt sync.
- Show sync and clear button only for connectable tags.