### PR TITLE
Make mergable frameworks to improve launch time

### DIFF
--- a/Packages/RuuviContext/target.yml
+++ b/Packages/RuuviContext/target.yml
@@ -1,6 +1,10 @@
 ---
 targets:
   RuuviContext:
+    # https://github.com/groue/GRDB.swift/issues/642
+    settings:
+      base:
+        MERGEABLE_LIBRARY: false
     templates:
     - Framework
     dependencies:

--- a/Packages/RuuviOntology/target.yml
+++ b/Packages/RuuviOntology/target.yml
@@ -1,6 +1,10 @@
 ---
 targets:
   RuuviOntology:
+    # https://github.com/groue/GRDB.swift/issues/642
+    settings:
+      base:
+        MERGEABLE_LIBRARY: false
     templates:
     - Framework
     dependencies:

--- a/Packages/RuuviPersistence/target.yml
+++ b/Packages/RuuviPersistence/target.yml
@@ -1,6 +1,10 @@
 ---
 targets:
   RuuviPersistence:
+    # https://github.com/groue/GRDB.swift/issues/642
+    settings:
+      base:
+        MERGEABLE_LIBRARY: false
     templates:
     - Framework
     dependencies:

--- a/Packages/RuuviReactor/target.yml
+++ b/Packages/RuuviReactor/target.yml
@@ -1,6 +1,10 @@
 ---
 targets:
   RuuviReactor:
+    # https://github.com/groue/GRDB.swift/issues/642
+    settings:
+      base:
+        MERGEABLE_LIBRARY: false
     templates:
     - Framework
     dependencies:

--- a/project_frameworks.yml
+++ b/project_frameworks.yml
@@ -50,6 +50,7 @@ targetTemplates:
         CFBundlePackageType: $(PRODUCT_BUNDLE_PACKAGE_TYPE)
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        MERGEABLE_LIBRARY: true
   Module:
     name: "${target_name}"
     type: framework
@@ -80,6 +81,7 @@ targetTemplates:
         CFBundlePackageType: $(PRODUCT_BUNDLE_PACKAGE_TYPE)
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        MERGEABLE_LIBRARY: true
   CommonFramework:
     name: "${target_name}"
     type: framework
@@ -110,6 +112,7 @@ targetTemplates:
         CFBundlePackageType: $(PRODUCT_BUNDLE_PACKAGE_TYPE)
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        MERGEABLE_LIBRARY: true
 
 packages:
   BTKit:

--- a/project_frameworks.yml
+++ b/project_frameworks.yml
@@ -259,6 +259,7 @@ targets:
         UIViewControllerBasedStatusBarAppearance: true
     settings:
       base:
+        MERGED_BINARY_TYPE: "manual"
         TARGETED_DEVICE_FAMILY: 1,2
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: true
         CODE_SIGN_ENTITLEMENTS: station/station.entitlements


### PR DESCRIPTION
Makes all frameworks, except depending on GRDB, mergable. 

@see https://developer.apple.com/documentation/xcode/configuring-your-project-to-use-mergeable-libraries#Manually-configure-merging. 

@see: https://github.com/groue/GRDB.swift/issues/642