### PR TITLE
Remove dependency on RuuviLocalization in RuuviDFU

### DIFF
--- a/Packages/RuuviDFU/Sources/RuuviDFU/RuuviDFUError.swift
+++ b/Packages/RuuviDFU/Sources/RuuviDFU/RuuviDFUError.swift
@@ -1,13 +1,6 @@
 import Foundation
-import RuuviLocalization
 
 public struct RuuviDfuError: Error {
-    public static let invalidFirmwareFile = RuuviDfuError(
-        description: RuuviLocalization.RuuviDfuError.invalidFirmwareFile
-    )
-    public static let failedToConstructUUID = RuuviDfuError(
-        description: RuuviLocalization.RuuviDfuError.failedToConstructUUID
-    )
     public let description: String
     public init(description: String) {
         self.description = description

--- a/Packages/RuuviDFU/Sources/RuuviDFUImpl/DfuFlasher.swift
+++ b/Packages/RuuviDFU/Sources/RuuviDFUImpl/DfuFlasher.swift
@@ -32,7 +32,8 @@ class DfuFlasher: NSObject {
     ) -> AnyPublisher<FlashResponse, Error> {
         guard let uuid = UUID(uuidString: uuid)
         else {
-            return Fail<FlashResponse, Error>(error: RuuviDfuError.failedToConstructUUID).eraseToAnyPublisher()
+            assertionFailure("Invalid UUID")
+            return Fail<FlashResponse, Error>(error: RuuviDfuError(description: "Invalid UUID")).eraseToAnyPublisher()
         }
         let subject = PassthroughSubject<FlashResponse, Error>()
         self.subject = subject

--- a/Packages/RuuviDFU/target.yml
+++ b/Packages/RuuviDFU/target.yml
@@ -8,4 +8,3 @@ targets:
       name: DFU
     dependencies:
     - package: NordicDFU
-    - target: RuuviLocalization


### PR DESCRIPTION
Motivation: for single used string for the invalid arg case its not necessary to link against RuuviLocalization