### PR TITLE
Dont remove localIds when signing out

### DIFF
--- a/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalIDs.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalIDs.swift
@@ -6,5 +6,4 @@ public protocol RuuviLocalIDs {
     func set(mac: MACIdentifier, for luid: LocalIdentifier)
     func luid(for mac: MACIdentifier) -> LocalIdentifier?
     func set(luid: LocalIdentifier, for mac: MACIdentifier)
-    func clear(sensor: RuuviTagSensor)
 }

--- a/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalIDsUserDefaults.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalIDsUserDefaults.swift
@@ -17,13 +17,4 @@ class RuuviLocalIDsUserDefaults: RuuviLocalIDs {
     func set(luid: LocalIdentifier, for mac: MACIdentifier) {
         UserDefaults.standard.set(luid.value, forKey: mac.value)
     }
-
-    func clear(sensor: RuuviTagSensor) {
-        if let luid = sensor.luid {
-            UserDefaults.standard.set(nil, forKey: luid.value)
-        }
-        if let macId = sensor.macId {
-            UserDefaults.standard.set(nil, forKey: macId.value)
-        }
-    }
 }

--- a/Packages/RuuviService/Sources/RuuviServiceAuth/RuuviServiceAuthImpl.swift
+++ b/Packages/RuuviService/Sources/RuuviServiceAuth/RuuviServiceAuthImpl.swift
@@ -51,7 +51,6 @@ public final class RuuviServiceAuthImpl: RuuviServiceAuth {
                     let deleteQueuedRequestsOperation = sSelf.pool.deleteQueuedRequests()
                     let cleanUpOperation = sSelf.pool.cleanupDBSpace()
                     sSelf.propertiesService.removeImage(for: sensor)
-                    sSelf.localIDs.clear(sensor: sensor)
                     sSelf.localSyncState.setSyncDate(nil, for: sensor.macId)
                     sSelf.localSyncState.setSyncDate(nil)
                     sSelf.localSyncState.setGattSyncDate(nil, for: sensor.macId)

--- a/Packages/RuuviService/Sources/RuuviServiceOwnership/RuuviServiceOwnershipImpl.swift
+++ b/Packages/RuuviService/Sources/RuuviServiceOwnership/RuuviServiceOwnershipImpl.swift
@@ -220,7 +220,6 @@ public final class RuuviServiceOwnershipImpl: RuuviServiceOwnership {
             }
         }
         propertiesService.removeImage(for: sensor)
-        localIDs.clear(sensor: sensor)
         Future.zip([
             deleteTagOperation,
             deleteRecordsOperation,


### PR DESCRIPTION
Its not private data, it is connected to this device [by uuid] only. Motivation: during sign out heartbeat received may fail to find macId