### PR TITLE
Listen to UUID updates for given MAC (#1841)

### DIFF
--- a/Packages/RuuviDaemon/Sources/RuuviDaemonRuuviTag/Properties/RuuviTagPropertiesDaemonBTKit.swift
+++ b/Packages/RuuviDaemon/Sources/RuuviDaemonRuuviTag/Properties/RuuviTagPropertiesDaemonBTKit.swift
@@ -111,6 +111,7 @@ public final class RuuviTagPropertiesDaemonBTKit: RuuviDaemonWorker, RuuviTagPro
 
     private func restartObserving() {
         removeTokens()
+        listenToUuidChangesForMac()
         for ruuviTag in ruuviTags {
             if let luid = ruuviTag.luid {
                 observeTokens.append(foreground.observe(
@@ -171,6 +172,21 @@ public final class RuuviTagPropertiesDaemonBTKit: RuuviDaemonWorker, RuuviTagPro
                     })
             }
         }
+    }
+
+    private func listenToUuidChangesForMac() {
+        let scanToken = foreground.scan(self, closure: { observer, device in
+            guard let tag = device.ruuvi?.tag,
+                  let luid = tag.luid,
+                  let macId = tag.macId
+            else {
+                return
+            }
+            if observer.idPersistence.luid(for: macId)?.any != luid.any {
+                observer.idPersistence.set(luid: luid, for: macId)
+            }
+        })
+        scanTokens.append(scanToken)
     }
 
     private func scanRemoteSensor(ruuviTag: AnyRuuviTagSensor) {


### PR DESCRIPTION
* Listen to UUID updates for given MAC E.g. the Ruuvi Tag could change its UUID because of update with nRF tools

* use observer instead of weka self