### PR TITLE
Don't support transferring Ruuvi Station data on device change

### DIFF
--- a/Apps/RuuviStation/Sources/Classes/Application/AppAssembly.swift
+++ b/Apps/RuuviStation/Sources/Classes/Application/AppAssembly.swift
@@ -58,6 +58,7 @@ private final class MigrationAssembly: Assembly {
             let settings = r.resolve(RuuviLocalSettings.self)!
             let idPersistence = r.resolve(RuuviLocalIDs.self)!
             let ruuviPool = r.resolve(RuuviPool.self)!
+            let sqliteContext = r.resolve(SQLiteContext.self)!
             let ruuviStorage = r.resolve(RuuviStorage.self)!
             let ruuviAlertService = r.resolve(RuuviServiceAlert.self)!
             let ruuviOffsetCalibrationService = r.resolve(RuuviServiceOffsetCalibration.self)!
@@ -65,6 +66,7 @@ private final class MigrationAssembly: Assembly {
                 settings: settings,
                 idPersistence: idPersistence,
                 ruuviPool: ruuviPool,
+                sqliteContext: sqliteContext,
                 ruuviStorage: ruuviStorage,
                 ruuviAlertService: ruuviAlertService,
                 ruuviOffsetCalibrationService: ruuviOffsetCalibrationService

--- a/Packages/RuuviMigration/Sources/RuuviMigrationImpl/IsExcludedFromBackup/MigrationManagerIsExcludedFromBackup.swift
+++ b/Packages/RuuviMigration/Sources/RuuviMigrationImpl/IsExcludedFromBackup/MigrationManagerIsExcludedFromBackup.swift
@@ -1,0 +1,26 @@
+import Foundation
+import RuuviContext
+
+final class MigrationManagerIsExcludedFromBackup: RuuviMigration {
+    private let sqliteContext: SQLiteContext
+
+    init(sqliteContext: SQLiteContext) {
+        self.sqliteContext = sqliteContext
+    }
+
+    func migrateIfNeeded() {
+        let databaseUrl = NSURL(fileURLWithPath: sqliteContext.database.dbPath)
+        do {
+            let resourceValues = try databaseUrl.resourceValues(forKeys: [.isExcludedFromBackupKey])
+            guard resourceValues[.isExcludedFromBackupKey] == nil
+                    || resourceValues[.isExcludedFromBackupKey] as? Bool == false else {
+                return
+            }
+            try databaseUrl.setResourceValue(true, forKey: .isExcludedFromBackupKey)
+        } catch let error as NSError {
+            print("Error excluding \(databaseUrl.lastPathComponent ?? "") from backup \(error)")
+        }
+    }
+
+    private let migratedUdKey = "MigrationManagerIsExcludedFromBackup.migrated"
+}

--- a/Packages/RuuviMigration/Sources/RuuviMigrationImpl/RuuviMigrationFactoryImpl.swift
+++ b/Packages/RuuviMigration/Sources/RuuviMigrationImpl/RuuviMigrationFactoryImpl.swift
@@ -8,6 +8,7 @@ public final class RuuviMigrationFactoryImpl: RuuviMigrationFactory {
     private let settings: RuuviLocalSettings
     private let idPersistence: RuuviLocalIDs
     private let ruuviPool: RuuviPool
+    private let sqliteContext: SQLiteContext
     private let ruuviStorage: RuuviStorage
     private let ruuviAlertService: RuuviServiceAlert
     private let ruuviOffsetCalibrationService: RuuviServiceOffsetCalibration
@@ -16,6 +17,7 @@ public final class RuuviMigrationFactoryImpl: RuuviMigrationFactory {
         settings: RuuviLocalSettings,
         idPersistence: RuuviLocalIDs,
         ruuviPool: RuuviPool,
+        sqliteContext: SQLiteContext,
         ruuviStorage: RuuviStorage,
         ruuviAlertService: RuuviServiceAlert,
         ruuviOffsetCalibrationService: RuuviServiceOffsetCalibration
@@ -23,6 +25,7 @@ public final class RuuviMigrationFactoryImpl: RuuviMigrationFactory {
         self.settings = settings
         self.idPersistence = idPersistence
         self.ruuviPool = ruuviPool
+        self.sqliteContext = sqliteContext
         self.ruuviStorage = ruuviStorage
         self.ruuviAlertService = ruuviAlertService
         self.ruuviOffsetCalibrationService = ruuviOffsetCalibrationService
@@ -50,6 +53,7 @@ public final class RuuviMigrationFactoryImpl: RuuviMigrationFactory {
             ruuviAlertService: ruuviAlertService
         )
         let toNetworkPull60 = MigrationManagerToNetworkPull60(settings: settings)
+        let isExcludedFromBackup = MigrationManagerIsExcludedFromBackup(sqliteContext: sqliteContext)
         return [
             toAlertService,
             toPrune240,
@@ -59,6 +63,7 @@ public final class RuuviMigrationFactoryImpl: RuuviMigrationFactory {
             toTimeouts,
             fixRHAlerts,
             toNetworkPull60,
+            isExcludedFromBackup,
         ]
     }
 }

--- a/Packages/RuuviUser/Sources/RuuviUserCoordinator/Keychain/Impl/KeychainServiceImpl.swift
+++ b/Packages/RuuviUser/Sources/RuuviUserCoordinator/Keychain/Impl/KeychainServiceImpl.swift
@@ -8,7 +8,7 @@ final class KeychainServiceImpl {
     )
     .label("Ruuvi Station")
     .synchronizable(false)
-    .accessibility(.afterFirstUnlock)
+    .accessibility(.afterFirstUnlockThisDeviceOnly)
 
     private enum Account: String {
         case ruuviUserApi


### PR DESCRIPTION
- introduces the migrateIfNeeded function, designed to modify the backup behavior of a specific SQLite database file used within the app. The primary objective is to ensure that this database file is not included in the iCloud backups.


- introduces a change in the configuration of a Keychain instance used in the app, specifically targeting the way the app handles the accessibility of the stored keychain items.


The significant change in this pull request is the modification of the keychain's accessibility attribute from .afterFirstUnlock to .afterFirstUnlockThisDeviceOnly. This change impacts when the keychain items become accessible:

Previously: .afterFirstUnlock - The keychain items were accessible after the device was first unlocked following a restart. This level allows the items to be accessible even when the device is locked again, as long as it hasn't been restarted.

Now: .afterFirstUnlockThisDeviceOnly - This setting is similar to .afterFirstUnlock in terms of accessibility after the device's first unlock. However, it adds an additional restriction that the items are only accessible on the current device. This means the keychain items are not included in device backups and cannot be restored to a new device.



