### PR TITLE
DFU improvements (#1856)

### DIFF
--- a/Apps/RuuviStation/Sources/Classes/Application/AppAssembly.swift
+++ b/Apps/RuuviStation/Sources/Classes/Application/AppAssembly.swift
@@ -640,8 +640,11 @@ private final class ModulesAssembly: Assembly {
             let permissionsManager = r.resolve(RuuviCorePermission.self)!
             let permissionPresenter = r.resolve(PermissionPresenter.self)!
             let foreground = r.resolve(BTForeground.self)!
+            let background = r.resolve(BTBackground.self)!
             let ruuviReactor = r.resolve(RuuviReactor.self)!
             let ruuviOwnershipService = r.resolve(RuuviServiceOwnership.self)!
+            let propertiesDaemon = r.resolve(RuuviTagPropertiesDaemon.self)!
+            let ruuviDFU = r.resolve(RuuviDFU.self)!
 
             let factory = RuuviDiscoverFactory()
             let dependencies = RuuviDiscoverDependencies(
@@ -650,6 +653,9 @@ private final class ModulesAssembly: Assembly {
                 permissionsManager: permissionsManager,
                 permissionPresenter: permissionPresenter,
                 foreground: foreground,
+                background: background,
+                propertiesDaemon: propertiesDaemon,
+                ruuviDFU: ruuviDFU,
                 ruuviReactor: ruuviReactor,
                 ruuviOwnershipService: ruuviOwnershipService,
                 firmwareBuilder: RuuviFirmwareBuilder()

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Cards/Router/CardsRouter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Cards/Router/CardsRouter.swift
@@ -41,13 +41,16 @@ class CardsRouter: NSObject, CardsRouterInput {
     func openUpdateFirmware(ruuviTag: RuuviTagSensor) {
         let factory: DFUModuleFactory = DFUModuleFactoryImpl()
         let module = factory.create(for: ruuviTag)
+        module.output = self
         dfuModule = module
         transitionHandler?
-            .navigationController?
-            .pushViewController(
+            .present(
                 module.viewController,
                 animated: true
             )
+        module.viewController
+            .presentationController?
+            .delegate = self
     }
 }
 
@@ -61,5 +64,17 @@ extension CardsRouter: DiscoverRouterDelegate {
         ruuviTag _: RuuviTagSensor
     ) {
         router.viewController.dismiss(animated: true)
+    }
+}
+
+extension CardsRouter: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerShouldDismiss(_: UIPresentationController) -> Bool {
+        dfuModule?.isSafeToDismiss() ?? true
+    }
+}
+
+extension CardsRouter: DFUModuleOutput {
+    func dfuModuleSuccessfullyUpgraded(_ dfuModule: DFUModuleInput) {
+        dfuModule.viewController.dismiss(animated: true)
     }
 }

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Home/Router/DashboardRouter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Home/Router/DashboardRouter.swift
@@ -213,15 +213,14 @@ class DashboardRouter: NSObject, DashboardRouterInput {
     func openUpdateFirmware(ruuviTag: RuuviTagSensor) {
         let factory: DFUModuleFactory = DFUModuleFactoryImpl()
         let module = factory.create(for: ruuviTag)
+        module.output = self
         dfuModule = module
         transitionHandler
-            .navigationController?
-            .pushViewController(
+            .present(
                 module.viewController,
                 animated: true
             )
-        transitionHandler
-            .navigationController?
+        module.viewController
             .presentationController?
             .delegate = self
     }
@@ -264,6 +263,16 @@ extension DashboardRouter: UIAdaptivePresentationControllerDelegate {
     func presentationControllerShouldDismiss(
         _: UIPresentationController
     ) -> Bool {
-        delegate.shouldDismissDiscover()
+        if let dfuModule {
+            dfuModule.isSafeToDismiss()
+        } else {
+            delegate.shouldDismissDiscover()
+        }
+    }
+}
+
+extension DashboardRouter: DFUModuleOutput {
+    func dfuModuleSuccessfullyUpgraded(_ dfuModule: DFUModuleInput) {
+        dfuModule.viewController.dismiss(animated: true)
     }
 }

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/DFU/Presenter/DFUModuleInput.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/DFU/Presenter/DFUModuleInput.swift
@@ -4,6 +4,10 @@ import UIKit
 
 protocol DFUModuleInput: AnyObject {
     var viewController: UIViewController { get }
-
+    var output: DFUModuleOutput? { get set }
     func isSafeToDismiss() -> Bool
+}
+
+protocol DFUModuleOutput: AnyObject {
+    func dfuModuleSuccessfullyUpgraded(_ dfuModule: DFUModuleInput)
 }

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/DFU/Presenter/DFUPresenter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/DFU/Presenter/DFUPresenter.swift
@@ -15,12 +15,13 @@ final class DFUPresenter: DFUModuleInput {
         if let view = weakView {
             return view
         } else {
+            viewModel.output = self
             let view = UIHostingController(rootView: DFUUIView(viewModel: viewModel))
             weakView = view
             return view
         }
     }
-
+    var output: DFUModuleOutput?
     private weak var weakView: UIViewController?
     private let viewModel: DFUViewModel
     private let interactor: DFUInteractorInput
@@ -77,5 +78,11 @@ final class DFUPresenter: DFUModuleInput {
         default:
             true
         }
+    }
+}
+
+extension DFUPresenter: DFUViewModelOutput {
+    func firmwareUpgradeDidFinishSuccessfully() {
+        output?.dfuModuleSuccessfullyUpgraded(self)
     }
 }

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/DFU/View/DFUViewModel.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/DFU/View/DFUViewModel.swift
@@ -11,12 +11,18 @@ import RuuviPool
 import RuuviPresenters
 import RuuviStorage
 
+protocol DFUViewModelOutput: AnyObject {
+    func firmwareUpgradeDidFinishSuccessfully()
+}
+
 final class DFUViewModel: ObservableObject {
     @Published private(set) var state: State = .idle
     @Published var downloadProgress: Double = 0
     @Published var flashProgress: Double = 0
     @Published var isMigrationFailed: Bool = false
 
+    var output: DFUViewModelOutput?
+    
     private var bag = Set<AnyCancellable>()
     private let input = PassthroughSubject<Event, Never>()
     private let interactor: DFUInteractorInput
@@ -36,16 +42,6 @@ final class DFUViewModel: ObservableObject {
     var isLoading: Bool = false {
         didSet {
             isLoading ? activityPresenter.show(with: .loading(message: nil)) : activityPresenter.dismiss()
-        }
-    }
-
-    private class RuuviTagPropertiesDaemonPair: NSObject {
-        var ruuviTag: AnyRuuviTagSensor
-        var device: RuuviTag
-
-        init(ruuviTag: AnyRuuviTagSensor, device: RuuviTag) {
-            self.ruuviTag = ruuviTag
-            self.device = device
         }
     }
 
@@ -103,6 +99,10 @@ final class DFUViewModel: ObservableObject {
 
     func send(event: Event) {
         input.send(event)
+    }
+
+    func finish() {
+        output?.firmwareUpgradeDidFinishSuccessfully()
     }
 
     func storeUpdatedFirmware(currentRelease: CurrentRelease?) {

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/DFU/View/SwiftUI/DFUUIView.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/DFU/View/SwiftUI/DFUUIView.swift
@@ -32,6 +32,7 @@ struct DFUUIView: View {
         let successfulTitle = RuuviLocalization.DFUUIView.successfulTitle
         let errorTitle = RuuviLocalization.ErrorPresenterAlert.error
         let dbMigrationErrorTitle = RuuviLocalization.DFUUIView.DBMigration.Error.message
+        let finish = RuuviLocalization.DfuFlash.Finish.text
     }
 
     private let muliBold16 = Font(UIFont.Muli(.bold, size: 16))
@@ -65,9 +66,11 @@ struct DFUUIView: View {
         })
         .onAppear {
             viewModel.send(event: .onAppear)
+            UIApplication.shared.isIdleTimerDisabled = true
         }
         .onDisappear {
             viewModel.restartPropertiesDaemon()
+            UIApplication.shared.isIdleTimerDisabled = false
         }
     }
 
@@ -433,16 +436,38 @@ struct DFUUIView: View {
                 .eraseToAnyView()
         case let .firmwareAfterUpdate(currentRelease):
             viewModel.storeUpdatedFirmware(currentRelease: currentRelease)
-            return Text(texts.successfulTitle)
-                .font(muliRegular16)
-                .foregroundColor(RuuviColor.textColor.swiftUIColor)
-                .frame(
-                    maxWidth: .infinity,
-                    maxHeight: .infinity,
-                    alignment: .topLeading
+            return VStack {
+                Text(texts.successfulTitle)
+                    .font(muliRegular16)
+                    .foregroundColor(RuuviColor.textColor.swiftUIColor)
+                    .frame(
+                        maxWidth: .infinity,
+                        maxHeight: .infinity,
+                        alignment: .topLeading
+                    )
+                    .padding()
+                Button(
+                    action: {
+                        viewModel.finish()
+                    },
+                    label: {
+                        Text(texts.finish)
+                            .font(muliBold16)
+                            .frame(maxWidth: .infinity)
+                    }
+                )
+                .buttonStyle(
+                    LargeButtonStyle(
+                        backgroundColor: RuuviColor.tintColor.swiftUIColor,
+                        foregroundColor: Color.white,
+                        isDisabled: false
+                    )
                 )
                 .padding()
-                .eraseToAnyView()
+                .frame(maxWidth: .infinity)
+            }
+            .padding()
+            .eraseToAnyView()
         }
     }
 

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/Owner/Router/OwnerRouter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/Owner/Router/OwnerRouter.swift
@@ -2,9 +2,9 @@ import LightRoute
 import RuuviOntology
 import UIKit
 
-final class OwnerRouter: OwnerRouterInput {
+final class OwnerRouter: NSObject, OwnerRouterInput {
     weak var transitionHandler: UIViewController!
-    private var dfuModule: DFUModuleInput?
+    private weak var dfuModule: DFUModuleInput?
 
     func dismiss() {
         try! transitionHandler.closeCurrentModule().perform()
@@ -13,12 +13,27 @@ final class OwnerRouter: OwnerRouterInput {
     func openUpdateFirmware(ruuviTag: RuuviTagSensor) {
         let factory: DFUModuleFactory = DFUModuleFactoryImpl()
         let module = factory.create(for: ruuviTag)
+        module.output = self
         dfuModule = module
         transitionHandler
-            .navigationController?
-            .pushViewController(
+            .present(
                 module.viewController,
                 animated: true
             )
+        module.viewController
+            .presentationController?
+            .delegate = self
+    }
+}
+
+extension OwnerRouter: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerShouldDismiss(_: UIPresentationController) -> Bool {
+        dfuModule?.isSafeToDismiss() ?? true
+    }
+}
+
+extension OwnerRouter: DFUModuleOutput {
+    func dfuModuleSuccessfullyUpgraded(_ dfuModule: DFUModuleInput) {
+        dfuModule.viewController.dismiss(animated: true)
     }
 }

--- a/Modules/RuuviDiscover/Sources/RuuviDiscover/RuuviDiscoverFactory.swift
+++ b/Modules/RuuviDiscover/Sources/RuuviDiscover/RuuviDiscoverFactory.swift
@@ -2,6 +2,8 @@ import BTKit
 import Foundation
 import RuuviContext
 import RuuviCore
+import RuuviDaemon
+import RuuviDFU
 import RuuviFirmware
 import RuuviLocal
 import RuuviPresenters
@@ -14,6 +16,9 @@ public struct RuuviDiscoverDependencies {
     var permissionsManager: RuuviCorePermission
     var permissionPresenter: PermissionPresenter
     var foreground: BTForeground
+    var background: BTBackground
+    var propertiesDaemon: RuuviTagPropertiesDaemon
+    var ruuviDFU: RuuviDFU
     var ruuviReactor: RuuviReactor
     var ruuviOwnershipService: RuuviServiceOwnership
     var firmwareBuilder: RuuviFirmwareBuilder
@@ -24,6 +29,9 @@ public struct RuuviDiscoverDependencies {
         permissionsManager: RuuviCorePermission,
         permissionPresenter: PermissionPresenter,
         foreground: BTForeground,
+        background: BTBackground,
+        propertiesDaemon: RuuviTagPropertiesDaemon,
+        ruuviDFU: RuuviDFU,
         ruuviReactor: RuuviReactor,
         ruuviOwnershipService: RuuviServiceOwnership,
         firmwareBuilder: RuuviFirmwareBuilder
@@ -33,6 +41,9 @@ public struct RuuviDiscoverDependencies {
         self.permissionsManager = permissionsManager
         self.permissionPresenter = permissionPresenter
         self.foreground = foreground
+        self.background = background
+        self.propertiesDaemon = propertiesDaemon
+        self.ruuviDFU = ruuviDFU
         self.ruuviReactor = ruuviReactor
         self.ruuviOwnershipService = ruuviOwnershipService
         self.firmwareBuilder = firmwareBuilder
@@ -49,6 +60,9 @@ public final class RuuviDiscoverFactory {
         presenter.permissionsManager = dependencies.permissionsManager
         presenter.permissionPresenter = dependencies.permissionPresenter
         presenter.foreground = dependencies.foreground
+        presenter.background = dependencies.background
+        presenter.propertiesDaemon = dependencies.propertiesDaemon
+        presenter.ruuviDFU = dependencies.ruuviDFU
         presenter.ruuviReactor = dependencies.ruuviReactor
         presenter.ruuviOwnershipService = dependencies.ruuviOwnershipService
         presenter.firmwareBuilder = dependencies.firmwareBuilder

--- a/Modules/RuuviDiscover/Sources/RuuviDiscover/VMP/Presenter/DiscoverPresenter.swift
+++ b/Modules/RuuviDiscover/Sources/RuuviDiscover/VMP/Presenter/DiscoverPresenter.swift
@@ -6,6 +6,8 @@ import Foundation
 import Future
 import RuuviContext
 import RuuviCore
+import RuuviDaemon
+import RuuviDFU
 import RuuviFirmware
 import RuuviLocal
 import RuuviLocalization
@@ -35,6 +37,9 @@ class DiscoverPresenter: NSObject, RuuviDiscover {
     var errorPresenter: ErrorPresenter!
     var activityPresenter: ActivityPresenter!
     var foreground: BTForeground!
+    var background: BTBackground!
+    var propertiesDaemon: RuuviTagPropertiesDaemon!
+    var ruuviDFU: RuuviDFU!
     var permissionsManager: RuuviCorePermission!
     var permissionPresenter: PermissionPresenter!
     var ruuviReactor: RuuviReactor!
@@ -261,7 +266,16 @@ extension DiscoverPresenter: DiscoverViewOutput {
 
     func viewDidAskToUpgradeFirmware(of sensor: NFCSensor?) {
         guard let sensor else { return }
-        let firmwareModule = firmwareBuilder.build(uuid: sensor.id, currentFirmware: sensor.firmwareVersion)
+        let firmwareModule = firmwareBuilder.build(
+            uuid: sensor.id,
+            currentFirmware: sensor.firmwareVersion,
+            dependencies: RuuviFirmwareDependencies(
+                background: background,
+                foreground: foreground,
+                propertiesDaemon: propertiesDaemon,
+                ruuviDFU: ruuviDFU
+            )
+        )
         firmwareModule.output = self
         viewController.present(firmwareModule.viewController, animated: true)
         self.firmwareModule = firmwareModule
@@ -276,7 +290,16 @@ extension DiscoverPresenter: DiscoverViewOutput {
     }
 
     func viewDidConfirmToUpdateFirmware(for uuid: String) {
-        let firmwareModule = firmwareBuilder.build(uuid: uuid, currentFirmware: "<=2.5.9")
+        let firmwareModule = firmwareBuilder.build(
+            uuid: uuid,
+            currentFirmware: "<=2.5.9",
+            dependencies: RuuviFirmwareDependencies(
+                background: background,
+                foreground: foreground,
+                propertiesDaemon: propertiesDaemon,
+                ruuviDFU: ruuviDFU
+            )
+        )
         firmwareModule.output = self
         let firmwareViewController = firmwareModule.viewController
         firmwareViewController.presentationController?.delegate = self

--- a/Modules/RuuviDiscover/target.yml
+++ b/Modules/RuuviDiscover/target.yml
@@ -11,6 +11,8 @@ targets:
     - package: Future
     - target: RuuviOntology
     - target: RuuviContext
+    - target: RuuviDaemon
+    - target: RuuviDFU
     - target: RuuviReactor
     - target: RuuviLocal
     - target: RuuviService

--- a/Modules/RuuviFirmware/Sources/RuuviFirmware/FirmwareInteractor.swift
+++ b/Modules/RuuviFirmware/Sources/RuuviFirmware/FirmwareInteractor.swift
@@ -1,6 +1,7 @@
 import BTKit
 import Combine
 import Foundation
+import RuuviDaemon
 import RuuviDFU
 
 struct CurrentRelease {
@@ -21,6 +22,7 @@ final class FirmwareInteractor {
     var batteryIsLow = CurrentValueSubject<Bool, Never>(false)
     private let background: BTBackground
     private let foreground: BTForeground
+    private let propertiesDaemon: RuuviTagPropertiesDaemon
     private let firmwareRepository: FirmwareRepository
     private let ruuviDFU: RuuviDFU
     private var ruuviTagObservationToken: ObservationToken?
@@ -28,17 +30,23 @@ final class FirmwareInteractor {
     init(
         background: BTBackground,
         foreground: BTForeground,
+        propertiesDaemon: RuuviTagPropertiesDaemon,
         ruuviDFU: RuuviDFU,
         firmwareRepository: FirmwareRepository
     ) {
         self.background = background
         self.foreground = foreground
+        self.propertiesDaemon = propertiesDaemon
         self.ruuviDFU = ruuviDFU
         self.firmwareRepository = firmwareRepository
     }
 
     deinit {
         ruuviTagObservationToken?.invalidate()
+    }
+
+    func restartPropertiesDaemon() {
+        propertiesDaemon.start()
     }
 
     func ensureBatteryHasEnoughPower(uuid: String) {

--- a/Modules/RuuviFirmware/Sources/RuuviFirmware/FirmwarePresenter.swift
+++ b/Modules/RuuviFirmware/Sources/RuuviFirmware/FirmwarePresenter.swift
@@ -1,4 +1,5 @@
 import BTKit
+import RuuviDaemon
 import RuuviDFU
 import SwiftUI
 import UIKit
@@ -35,6 +36,7 @@ final class FirmwarePresenter: RuuviFirmware {
         currentFirmware: String?,
         background: BTBackground,
         foreground: BTForeground,
+        propertiesDaemon: RuuviTagPropertiesDaemon,
         ruuviDFU: RuuviDFU,
         firmwareRepository: FirmwareRepository
     ) {
@@ -43,6 +45,7 @@ final class FirmwarePresenter: RuuviFirmware {
         interactor = FirmwareInteractor(
             background: background,
             foreground: foreground,
+            propertiesDaemon: propertiesDaemon,
             ruuviDFU: ruuviDFU,
             firmwareRepository: firmwareRepository
         )

--- a/Modules/RuuviFirmware/Sources/RuuviFirmware/RuuviFirmwareBuilder.swift
+++ b/Modules/RuuviFirmware/Sources/RuuviFirmware/RuuviFirmwareBuilder.swift
@@ -1,11 +1,24 @@
 import BTKit
+import RuuviDaemon
 import RuuviDFU
 
 public struct RuuviFirmwareDependencies {
     public var background: BTBackground
     public var foreground: BTForeground
+    public var propertiesDaemon: RuuviTagPropertiesDaemon
     public var ruuviDFU: RuuviDFU
-    public var firmwareRepository: FirmwareRepository
+
+    public init(
+        background: BTBackground,
+        foreground: BTForeground,
+        propertiesDaemon: RuuviTagPropertiesDaemon,
+        ruuviDFU: RuuviDFU
+    ) {
+        self.background = background
+        self.foreground = foreground
+        self.propertiesDaemon = propertiesDaemon
+        self.ruuviDFU = ruuviDFU
+    }
 }
 
 public final class RuuviFirmwareBuilder {
@@ -14,27 +27,17 @@ public final class RuuviFirmwareBuilder {
     public func build(
         uuid: String,
         currentFirmware: String? = nil,
-        dependencies: RuuviFirmwareDependencies = .default
+        dependencies: RuuviFirmwareDependencies
     ) -> RuuviFirmware {
         let presenter = FirmwarePresenter(
             uuid: uuid,
             currentFirmware: currentFirmware,
             background: dependencies.background,
             foreground: dependencies.foreground,
+            propertiesDaemon: dependencies.propertiesDaemon,
             ruuviDFU: dependencies.ruuviDFU,
-            firmwareRepository: dependencies.firmwareRepository
-        )
-        return presenter
-    }
-}
-
-public extension RuuviFirmwareDependencies {
-    static var `default`: Self {
-        RuuviFirmwareDependencies(
-            background: BTKit.background,
-            foreground: BTKit.foreground,
-            ruuviDFU: RuuviDFUImpl.shared,
             firmwareRepository: FirmwareRepositoryImpl()
         )
+        return presenter
     }
 }

--- a/Modules/RuuviFirmware/Sources/RuuviFirmware/SwiftUI/FirmwareView.swift
+++ b/Modules/RuuviFirmware/Sources/RuuviFirmware/SwiftUI/FirmwareView.swift
@@ -440,6 +440,11 @@ struct FirmwareView: View {
         .navigationBarBackButtonHidden(true)
         .onAppear {
             viewModel.send(event: .onAppear)
+            UIApplication.shared.isIdleTimerDisabled = true
+        }
+        .onDisappear {
+            viewModel.restartPropertiesDaemon()
+            UIApplication.shared.isIdleTimerDisabled = false
         }
     }
 }

--- a/Modules/RuuviFirmware/Sources/RuuviFirmware/SwiftUI/FirmwareViewModel.swift
+++ b/Modules/RuuviFirmware/Sources/RuuviFirmware/SwiftUI/FirmwareViewModel.swift
@@ -59,6 +59,10 @@ final class FirmwareViewModel: ObservableObject {
     func ensureBatteryHasEnoughPower(uuid: String) {
         interactor.ensureBatteryHasEnoughPower(uuid: uuid)
     }
+
+    func restartPropertiesDaemon() {
+        interactor.restartPropertiesDaemon()
+    }
 }
 
 // MARK: - Feedbacks

--- a/Modules/RuuviFirmware/target.yml
+++ b/Modules/RuuviFirmware/target.yml
@@ -11,5 +11,6 @@ targets:
     - Module
     dependencies:
     - package: BTKit
+    - target: RuuviDaemon
     - target: RuuviDFU
     - target: RuuviLocalization


### PR DESCRIPTION
* Idle Timer and Properties Daemon for Firmware Upgrade Implements dont lock screen feature during firmware upgrade and fixes missing charts icon with properties daemon restart

* Ensure you cant dismiss DFU module during upgrade And present it modally, not pushing