### PR TITLE
Fix removal description of not shared sensor

### DIFF
--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/Removal/Presenter/SensorRemovalPresenter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/Removal/Presenter/SensorRemovalPresenter.swift
@@ -30,11 +30,7 @@ final class SensorRemovalPresenter: SensorRemovalModuleInput {
 extension SensorRemovalPresenter: SensorRemovalViewOutput {
     func viewDidLoad() {
         guard let ruuviTag else { return }
-        view?.updateView(
-            claimedAndOwned: ruuviTag.isClaimed && ruuviTag.isOwner,
-            locallyOwned: !ruuviTag.isClaimed && ruuviTag.isOwner,
-            shared: !ruuviTag.isOwner
-        )
+        view?.updateView(ownership: ruuviTag.ownership)
     }
 
     func viewDidTriggerRemoveTag() {

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/Removal/View/SensorRemovalViewInput.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/Removal/View/SensorRemovalViewInput.swift
@@ -1,6 +1,7 @@
 import Foundation
+import RuuviOntology
 
 protocol SensorRemovalViewInput: ViewInput {
-    func updateView(claimedAndOwned: Bool, locallyOwned: Bool, shared: Bool)
+    func updateView(ownership: SensorOwnership)
     func showHistoryDataRemovalConfirmationDialog()
 }

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/Removal/View/UI/SensorRemovalViewController.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/TagSettings/Submodules/Removal/View/UI/SensorRemovalViewController.swift
@@ -92,26 +92,24 @@ extension SensorRemovalViewController: SensorRemovalViewInput {
         // No op.
     }
 
-    func updateView(claimedAndOwned: Bool, locallyOwned: Bool, shared: Bool) {
-        var message = ""
-        if claimedAndOwned {
-            message = RuuviLocalization.removeClaimedSensorDescription
+    func updateView(ownership: SensorOwnership) {
+        switch ownership {
+        case .claimedByMe:
+            messageLabel.text = RuuviLocalization.removeClaimedSensorDescription
+            removeButtonConstraintClaimedSensor.isActive = true
+            removeButtonConstraintOtherSensor.isActive = false
+            removeCloudHistoryActionContainer.isHidden = false
+        case .sharedWithMe:
+            messageLabel.text = RuuviLocalization.removeSharedSensorDescription
+            removeButtonConstraintClaimedSensor.isActive = false
+            removeButtonConstraintOtherSensor.isActive = true
+            removeCloudHistoryActionContainer.isHidden = true
+        case .locallyAddedButNotMine, .locallyAddedAndNotClaimed:
+            messageLabel.text = RuuviLocalization.removeLocalSensorDescription
+            removeButtonConstraintClaimedSensor.isActive = false
+            removeButtonConstraintOtherSensor.isActive = true
+            removeCloudHistoryActionContainer.isHidden = true
         }
-
-        if locallyOwned {
-            message = RuuviLocalization.removeLocalSensorDescription
-        }
-
-        if shared {
-            message = RuuviLocalization.removeSharedSensorDescription
-        }
-
-        messageLabel.text = message
-
-        removeButtonConstraintClaimedSensor.isActive = claimedAndOwned
-        removeButtonConstraintOtherSensor.isActive = locallyOwned || shared
-
-        removeCloudHistoryActionContainer.isHidden = locallyOwned || shared
     }
 
     func showHistoryDataRemovalConfirmationDialog() {

--- a/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/RuuviTag/RuuviTagSensor.swift
+++ b/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/RuuviTag/RuuviTagSensor.swift
@@ -3,6 +3,13 @@ import Foundation
 
 public protocol RuuviTagSensor: PhysicalSensor, Versionable, Claimable, Connectable, Nameable, Shareable {}
 
+public enum SensorOwnership {
+    case claimedByMe
+    case sharedWithMe
+    case locallyAddedButNotMine
+    case locallyAddedAndNotClaimed
+}
+
 public extension RuuviTagSensor {
     var id: String {
         if let macId,
@@ -12,6 +19,19 @@ public extension RuuviTagSensor {
             luid.value
         } else {
             fatalError()
+        }
+    }
+
+    var ownership: SensorOwnership {
+        switch (isClaimed, isCloud, isOwner) {
+        case (true, _, _):
+            return .claimedByMe
+        case (false, true, false):
+            return .sharedWithMe
+        case (false, _, false):
+            return .locallyAddedButNotMine
+        case (false, _, true):
+            return .locallyAddedAndNotClaimed
         }
     }
 


### PR DESCRIPTION
Previousely shared was determined by just `shared: !ruuviTag.isOwner`. This is obviousely incorrect, so I added ownership enum. Fixes #1913