### PR TITLE
Avoid asking for BT permission on onboarding

### DIFF
--- a/Packages/RuuviDaemon/Sources/RuuviDaemonRuuviTag/Properties/RuuviTagPropertiesDaemonBTKit.swift
+++ b/Packages/RuuviDaemon/Sources/RuuviDaemonRuuviTag/Properties/RuuviTagPropertiesDaemonBTKit.swift
@@ -59,7 +59,9 @@ public final class RuuviTagPropertiesDaemonBTKit: RuuviDaemonWorker, RuuviTagPro
                 switch change {
                 case let .initial(ruuviTags):
                     sSelf.ruuviTags = ruuviTags
-                    sSelf.restartObserving()
+                    if !ruuviTags.isEmpty {
+                        sSelf.restartObserving()
+                    }
                 case let .update(ruuviTag):
                     if let index = sSelf.ruuviTags
                         .firstIndex(


### PR DESCRIPTION
Stop subscribing to BTKit if there are no RuuviTags added yet.