### PR TITLE
Dirty working fix for min/max/avg calc

### DIFF
--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Charts/View/UI/TagChartsViewController.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Charts/View/UI/TagChartsViewController.swift
@@ -1050,7 +1050,13 @@ extension TagChartsViewController {
         view.setXAxisRenderer()
         view.setChartStatVisible(show: showChartStat)
 
-        calculateMinMaxForChart(for: view)
+        // Calculation of min/max depends on the chart
+        // internal viewport state. Give it a chance to
+        // redraw itself before calculation.
+        // Fixes https://github.com/ruuvi/com.ruuvi.station.ios/issues/1758
+        DispatchQueue.main.async { [weak self] in
+            self?.calculateMinMaxForChart(for: view)
+        }
     }
 
     private func clearChartData() {


### PR DESCRIPTION
Because calc depends on lowestVisibleX, and it depends on viewport, we have to wait until it recalculates after assigning data. Fixes #1758