### PR TITLE
fix: Limit alert notifications not respecting the settings #1879

### DIFF
--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Settings/Submodules/Defaults/Presenter/DefaultsPresenter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Settings/Submodules/Defaults/Presenter/DefaultsPresenter.swift
@@ -28,6 +28,7 @@ class DefaultsPresenter: NSObject, DefaultsModuleInput {
             buildChartIntervalSeconds(),
             buildChartDurationHours(),
             saveAdvertisementsInterval(),
+            saveHeartbeatsForgroundInterval(),
             buildAskForReviewFirstTime(),
             buildAskForReviewLater(),
             buildDashboardCardTapAction(),
@@ -188,6 +189,19 @@ extension DefaultsPresenter {
             observer.settings.chartDurationHours = chartDurationHours.bound
         }
         return chartDurationHours
+    }
+
+    private func saveHeartbeatsForgroundInterval() -> DefaultsViewModel {
+        let heartbeatsInterval = DefaultsViewModel()
+        heartbeatsInterval.title = RuuviLocalization.Defaults.BackgroundScanning.Foreground.interval
+        heartbeatsInterval.integer.value = settings.saveHeartbeatsForegroundIntervalSeconds
+        heartbeatsInterval.unit = .seconds
+        heartbeatsInterval.type.value = .stepper
+
+        bind(heartbeatsInterval.integer, fire: false) { observer, interval in
+            observer.settings.saveHeartbeatsForegroundIntervalSeconds = interval.bound
+        }
+        return heartbeatsInterval
     }
 
     private func saveAdvertisementsInterval() -> DefaultsViewModel {

--- a/Packages/RuuviDaemon/Sources/RuuviDaemonRuuviTag/Heartbeat/RuuviTagHeartbeatDaemonBTKit.swift
+++ b/Packages/RuuviDaemon/Sources/RuuviDaemonRuuviTag/Heartbeat/RuuviTagHeartbeatDaemonBTKit.swift
@@ -239,8 +239,9 @@ extension RuuviTagHeartbeatDaemonBTKit {
                     // If the app is on foreground store all heartbeats
                     // Otherwise respect the settings
                     guard ruuviTag.luid != nil else { return }
-                    // swiftlint:disable:next line_length
-                    let interval = observer.settings.appIsOnForeground ? 2 : (observer.settings.saveHeartbeatsIntervalMinutes * 60)
+                    let interval = observer.settings.appIsOnForeground ?
+                        (observer.settings.saveHeartbeatsForegroundIntervalSeconds) :
+                        (observer.settings.saveHeartbeatsIntervalMinutes * 60)
                     if let date = observer.savedDate[uuid] {
                         if Date().timeIntervalSince(date) > TimeInterval(interval) {
                             self.createRecords(

--- a/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalSettings.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalSettings.swift
@@ -62,6 +62,7 @@ public protocol RuuviLocalSettings {
     var alertsMuteIntervalMinutes: Int { get set }
     var saveHeartbeats: Bool { get set }
     var saveHeartbeatsIntervalMinutes: Int { get set }
+    var saveHeartbeatsForegroundIntervalSeconds: Int { get set }
     var webPullIntervalMinutes: Int { get set }
     var dataPruningOffsetHours: Int { get set }
     var chartIntervalSeconds: Int { get set }

--- a/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalSettingsUserDefaults.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalSettingsUserDefaults.swift
@@ -282,6 +282,9 @@ final class RuuviLocalSettingsUserDefaults: RuuviLocalSettings {
     @UserDefault("SettingsUserDegaults.saveHeartbeatsIntervalMinutes", defaultValue: 5)
     var saveHeartbeatsIntervalMinutes: Int
 
+    @UserDefault("SettingsUserDefaults.saveHeartbeatsForegroundIntervalSeconds", defaultValue: 2)
+    var saveHeartbeatsForegroundIntervalSeconds: Int
+
     @UserDefault("SettingsUserDegaults.webPullIntervalMinutes", defaultValue: 15)
     var webPullIntervalMinutes: Int
 

--- a/Packages/RuuviNotification/Sources/RuuviNotificationLocal/RuuviNotificationLocalImpl.swift
+++ b/Packages/RuuviNotification/Sources/RuuviNotificationLocal/RuuviNotificationLocalImpl.swift
@@ -84,9 +84,7 @@ public final class RuuviNotificationLocalImpl: NSObject, RuuviNotificationLocal 
 
     public func showDidConnect(uuid: String, title: String) {
         isMuted(for: .connection, uuid: uuid) { [weak self] muted in
-            if muted {
-                return
-            }
+            guard !muted else { return }
             guard let sSelf = self else { return }
 
             let content = UNMutableNotificationContent()
@@ -129,9 +127,7 @@ public final class RuuviNotificationLocalImpl: NSObject, RuuviNotificationLocal 
 
     public func showDidDisconnect(uuid: String, title: String) {
         isMuted(for: .connection, uuid: uuid) { [weak self] muted in
-            if muted {
-                return
-            }
+            guard !muted else { return }
 
             guard let sSelf = self else { return }
             let content = UNMutableNotificationContent()
@@ -174,9 +170,7 @@ public final class RuuviNotificationLocalImpl: NSObject, RuuviNotificationLocal 
 
     public func notifyDidMove(for uuid: String, counter _: Int, title: String) {
         isMuted(for: .movement(last: 0), uuid: uuid) { [weak self] muted in
-            if muted {
-                return
-            }
+            guard !muted else { return }
 
             guard let sSelf = self else { return }
 
@@ -230,9 +224,7 @@ public extension RuuviNotificationLocalImpl {
         title: String
     ) {
         isMuted(for: Self.alertType(from: type), uuid: uuid) { [weak self] muted in
-            if muted {
-                return
-            }
+            guard !muted else { return }
             guard let sSelf = self else { return }
 
             let content = UNMutableNotificationContent()

--- a/Packages/RuuviNotification/Sources/RuuviNotificationLocal/RuuviNotificationLocalImpl.swift
+++ b/Packages/RuuviNotification/Sources/RuuviNotificationLocal/RuuviNotificationLocalImpl.swift
@@ -40,20 +40,6 @@ public final class RuuviNotificationLocalImpl: NSObject, RuuviNotificationLocal 
         self.ruuviAlertService = ruuviAlertService
     }
 
-    var lowTemperatureAlerts = [String: Date]()
-    var highTemperatureAlerts = [String: Date]()
-    var lowHumidityAlerts = [String: Date]()
-    var highHumidityAlerts = [String: Date]()
-    var lowRelativeHumidityAlerts = [String: Date]()
-    var highRelativeHumidityAlerts = [String: Date]()
-    var lowPressureAlerts = [String: Date]()
-    var highPressureAlerts = [String: Date]()
-    var lowSignalAlerts = [String: Date]()
-    var highSignalAlerts = [String: Date]()
-    var movementAlerts = [String: Date]()
-    var connectAlerts = [String: Date]()
-    var disconnectAlerts = [String: Date]()
-
     private let lowHigh = LocalAlertCategory(
         id: "com.ruuvi.station.alerts.lh",
         disable: "com.ruuvi.station.alerts.lh.disable",
@@ -68,6 +54,13 @@ public final class RuuviNotificationLocalImpl: NSObject, RuuviNotificationLocal 
         uuidKey: "com.ruuvi.station.alerts.blast.uuid",
         typeKey: "com.ruuvi.station.alerts.blast.type"
     )
+
+    private let dateFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.locale = Locale.autoupdatingCurrent
+        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        return df
+    }()
 
     private var alertDidChangeToken: NSObjectProtocol?
 
@@ -90,150 +83,137 @@ public final class RuuviNotificationLocalImpl: NSObject, RuuviNotificationLocal 
     }
 
     public func showDidConnect(uuid: String, title: String) {
-        var needsToShow: Bool
-        let cache: [String: Date] = connectAlerts
-
-        if let shownDate = cache[uuid] {
-            var intervalPassed = true
-            if settings.limitAlertNotificationsEnabled {
-                intervalPassed = Date() > lastTriggerOffset(from: shownDate)
+        isMuted(for: .connection, uuid: uuid) { [weak self] muted in
+            if muted {
+                return
             }
+            guard let sSelf = self else { return }
 
-            if let mutedTill = ruuviAlertService.mutedTill(type: .connection, for: uuid) {
-                needsToShow = intervalPassed && (Date() > mutedTill)
-            } else {
-                needsToShow = intervalPassed
-            }
-        } else if let mutedTill = ruuviAlertService.mutedTill(type: .connection, for: uuid) {
-            needsToShow = Date() > mutedTill
-        } else {
-            needsToShow = true
-        }
-
-        if needsToShow {
             let content = UNMutableNotificationContent()
             content.title = title
-            switch settings.alertSound {
+            switch sSelf.settings.alertSound {
             case .systemDefault:
                 content.sound = .default
             default:
                 content.sound = UNNotificationSound(
-                    named: UNNotificationSoundName(rawValue: settings.alertSound.rawValue)
+                    named: UNNotificationSoundName(
+                        rawValue: sSelf.settings.alertSound.rawValue
+                    )
                 )
             }
-            content.userInfo = [blast.uuidKey: uuid, blast.typeKey: BlastNotificationType.connection.rawValue]
-            content.categoryIdentifier = blast.id
-            setAlertBadge(for: content)
+            content.userInfo = [
+                sSelf.blast.uuidKey: uuid,
+                sSelf.blast.typeKey: BlastNotificationType.connection.rawValue,
+            ]
+            content.categoryIdentifier = sSelf.blast.id
+            sSelf.setAlertBadge(for: content)
 
-            ruuviStorage.readOne(id(for: uuid)).on(success: { [weak self] ruuviTag in
+            sSelf.ruuviStorage.readOne(sSelf.id(for: uuid)).on(success: { [weak self] ruuviTag in
                 guard let sSelf = self else { return }
                 content.subtitle = ruuviTag.name
                 content.body = sSelf.ruuviAlertService.connectionDescription(for: uuid) ?? ""
-                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
-                let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+                let trigger = UNTimeIntervalNotificationTrigger(
+                    timeInterval: 0.1,
+                    repeats: false
+                )
+                let request = UNNotificationRequest(
+                    identifier: UUID().uuidString,
+                    content: content,
+                    trigger: trigger
+                )
                 UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+                sSelf.setTriggered(for: Self.alertType(from: .connection), uuid: uuid)
             })
-
-            connectAlerts[uuid] = Date()
         }
     }
 
     public func showDidDisconnect(uuid: String, title: String) {
-        var needsToShow: Bool
-        let cache: [String: Date] = disconnectAlerts
-
-        if let shownDate = cache[uuid] {
-            var intervalPassed = true
-            if settings.limitAlertNotificationsEnabled {
-                intervalPassed = Date() > lastTriggerOffset(from: shownDate)
+        isMuted(for: .connection, uuid: uuid) { [weak self] muted in
+            if muted {
+                return
             }
 
-            if let mutedTill = ruuviAlertService.mutedTill(type: .connection, for: uuid) {
-                needsToShow = intervalPassed && (Date() > mutedTill)
-            } else {
-                needsToShow = intervalPassed
-            }
-        } else if let mutedTill = ruuviAlertService.mutedTill(type: .connection, for: uuid) {
-            needsToShow = Date() > mutedTill
-        } else {
-            needsToShow = true
-        }
-
-        if needsToShow {
+            guard let sSelf = self else { return }
             let content = UNMutableNotificationContent()
-            switch settings.alertSound {
+            switch sSelf.settings.alertSound {
             case .systemDefault:
                 content.sound = .default
             default:
                 content.sound = UNNotificationSound(
-                    named: UNNotificationSoundName(rawValue: settings.alertSound.rawValue)
+                    named: UNNotificationSoundName(
+                        rawValue: sSelf.settings.alertSound.rawValue
+                    )
                 )
             }
-            content.userInfo = [blast.uuidKey: uuid, blast.typeKey: BlastNotificationType.connection.rawValue]
-            content.categoryIdentifier = blast.id
+            content.userInfo = [
+                sSelf.blast.uuidKey: uuid,
+                sSelf.blast.typeKey: BlastNotificationType.connection.rawValue,
+            ]
+            content.categoryIdentifier = sSelf.blast.id
             content.title = title
-            setAlertBadge(for: content)
+            sSelf.setAlertBadge(for: content)
 
-            ruuviStorage.readOne(id(for: uuid)).on(success: { [weak self] ruuviTag in
+            sSelf.ruuviStorage.readOne(sSelf.id(for: uuid)).on(success: { [weak self] ruuviTag in
                 guard let sSelf = self else { return }
                 content.subtitle = ruuviTag.name
                 content.body = sSelf.ruuviAlertService.connectionDescription(for: uuid) ?? ""
-                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
-                let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+                let trigger = UNTimeIntervalNotificationTrigger(
+                    timeInterval: 0.1,
+                    repeats: false
+                )
+                let request = UNNotificationRequest(
+                    identifier: UUID().uuidString,
+                    content: content,
+                    trigger: trigger
+                )
                 UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+                sSelf.setTriggered(for: Self.alertType(from: .connection), uuid: uuid)
             })
-
-            disconnectAlerts[uuid] = Date()
         }
     }
 
     public func notifyDidMove(for uuid: String, counter _: Int, title: String) {
-        var needsToShow: Bool
-        let cache: [String: Date] = movementAlerts
-
-        if let shownDate = cache[uuid] {
-            var intervalPassed = true
-            if settings.limitAlertNotificationsEnabled {
-                intervalPassed = Date() > lastTriggerOffset(from: shownDate)
+        isMuted(for: .movement(last: 0), uuid: uuid) { [weak self] muted in
+            if muted {
+                return
             }
 
-            if let mutedTill = ruuviAlertService.mutedTill(type: .movement(last: 0), for: uuid) {
-                needsToShow = intervalPassed && (Date() > mutedTill)
-            } else {
-                needsToShow = intervalPassed
-            }
-        } else if let mutedTill = ruuviAlertService.mutedTill(type: .movement(last: 0), for: uuid) {
-            needsToShow = Date() > mutedTill
-        } else {
-            needsToShow = true
-        }
+            guard let sSelf = self else { return }
 
-        if needsToShow {
             let content = UNMutableNotificationContent()
-            switch settings.alertSound {
+            switch sSelf.settings.alertSound {
             case .systemDefault:
                 content.sound = .default
             default:
                 content.sound = UNNotificationSound(
-                    named: UNNotificationSoundName(rawValue: settings.alertSound.rawValue)
+                    named: UNNotificationSoundName(rawValue: sSelf.settings.alertSound.rawValue)
                 )
             }
-            content.userInfo = [blast.uuidKey: uuid, blast.typeKey: BlastNotificationType.movement.rawValue]
-            content.categoryIdentifier = blast.id
-            setAlertBadge(for: content)
+            content.userInfo = [
+                sSelf.blast.uuidKey: uuid,
+                sSelf.blast.typeKey: BlastNotificationType.movement.rawValue,
+            ]
+            content.categoryIdentifier = sSelf.blast.id
+            sSelf.setAlertBadge(for: content)
 
             content.title = title
 
-            ruuviStorage.readOne(id(for: uuid)).on(success: { [weak self] ruuviTag in
+            sSelf.ruuviStorage.readOne(sSelf.id(for: uuid)).on(success: { [weak self] ruuviTag in
                 guard let sSelf = self else { return }
                 content.subtitle = ruuviTag.name
                 content.body = sSelf.ruuviAlertService.movementDescription(for: uuid) ?? ""
-                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
-                let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+                let trigger = UNTimeIntervalNotificationTrigger(
+                    timeInterval: 0.1,
+                    repeats: false
+                )
+                let request = UNNotificationRequest(
+                    identifier: UUID().uuidString,
+                    content: content,
+                    trigger: trigger
+                )
                 UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+                sSelf.setTriggered(for: Self.alertType(from: .movement), uuid: uuid)
             })
-
-            movementAlerts[uuid] = Date()
         }
     }
 }
@@ -241,131 +221,67 @@ public final class RuuviNotificationLocalImpl: NSObject, RuuviNotificationLocal 
 // MARK: - Notify
 
 public extension RuuviNotificationLocalImpl {
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
+
+    // swiftlint:disable:next function_body_length
     func notify(
         _ reason: LowHighNotificationReason,
         _ type: LowHighNotificationType,
         for uuid: String,
         title: String
     ) {
-        var needsToShow: Bool
-        let cache: [String: Date] = switch reason {
-        case .low:
-            switch type {
-            case .temperature:
-                lowTemperatureAlerts
-            case .relativeHumidity:
-                lowRelativeHumidityAlerts
-            case .humidity:
-                lowHumidityAlerts
-            case .pressure:
-                lowPressureAlerts
-            case .signal:
-                lowSignalAlerts
+        isMuted(for: Self.alertType(from: type), uuid: uuid) { [weak self] muted in
+            if muted {
+                return
             }
-        case .high:
-            switch type {
-            case .temperature:
-                highTemperatureAlerts
-            case .relativeHumidity:
-                highRelativeHumidityAlerts
-            case .humidity:
-                highHumidityAlerts
-            case .pressure:
-                highPressureAlerts
-            case .signal:
-                highSignalAlerts
-            }
-        }
+            guard let sSelf = self else { return }
 
-        if let shownDate = cache[uuid] {
-            var intervalPassed = false
-            if settings.limitAlertNotificationsEnabled {
-                intervalPassed = Date() > lastTriggerOffset(from: shownDate)
-            } else {
-                intervalPassed =
-                    Date().timeIntervalSince(shownDate) >=
-                    TimeInterval(settings.saveHeartbeatsIntervalMinutes * 60)
-            }
-
-            if let mutedTill = ruuviAlertService.mutedTill(type: Self.alertType(from: type), for: uuid) {
-                needsToShow = intervalPassed && (Date() > mutedTill)
-            } else {
-                needsToShow = intervalPassed
-            }
-        } else if let mutedTill = ruuviAlertService.mutedTill(type: Self.alertType(from: type), for: uuid) {
-            needsToShow = Date() > mutedTill
-        } else {
-            needsToShow = true
-        }
-        if needsToShow {
             let content = UNMutableNotificationContent()
-            switch settings.alertSound {
+            switch sSelf.settings.alertSound {
             case .systemDefault:
                 content.sound = .default
             default:
                 content.sound = UNNotificationSound(
-                    named: UNNotificationSoundName(rawValue: settings.alertSound.rawValue)
+                    named: UNNotificationSoundName(
+                        rawValue: sSelf.settings.alertSound.rawValue
+                    )
                 )
             }
             content.title = title
-            content.userInfo = [lowHigh.uuidKey: uuid, lowHigh.typeKey: type.rawValue]
-            content.categoryIdentifier = lowHigh.id
-            setAlertBadge(for: content)
+            content.userInfo = [
+                sSelf.lowHigh.uuidKey: uuid,
+                sSelf.lowHigh.typeKey: type.rawValue,
+            ]
+            content.categoryIdentifier = sSelf.lowHigh.id
+            sSelf.setAlertBadge(for: content)
 
             let body: String = switch type {
             case .temperature:
-                ruuviAlertService.temperatureDescription(for: uuid) ?? ""
+                sSelf.ruuviAlertService.temperatureDescription(for: uuid) ?? ""
             case .relativeHumidity:
-                ruuviAlertService.relativeHumidityDescription(for: uuid) ?? ""
+                sSelf.ruuviAlertService.relativeHumidityDescription(for: uuid) ?? ""
             case .humidity:
-                ruuviAlertService.humidityDescription(for: uuid) ?? ""
+                sSelf.ruuviAlertService.humidityDescription(for: uuid) ?? ""
             case .pressure:
-                ruuviAlertService.pressureDescription(for: uuid) ?? ""
+                sSelf.ruuviAlertService.pressureDescription(for: uuid) ?? ""
             case .signal:
-                ruuviAlertService.signalDescription(for: uuid) ?? ""
+                sSelf.ruuviAlertService.signalDescription(for: uuid) ?? ""
             }
             content.body = body
 
-            ruuviStorage.readOne(id(for: uuid)).on(success: { ruuviTag in
+            sSelf.ruuviStorage.readOne(sSelf.id(for: uuid)).on(success: { [weak self] ruuviTag in
                 content.subtitle = ruuviTag.name
-                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
+                let trigger = UNTimeIntervalNotificationTrigger(
+                    timeInterval: 0.1,
+                    repeats: false
+                )
                 let request = UNNotificationRequest(
                     identifier: uuid + type.rawValue,
                     content: content,
                     trigger: trigger
                 )
                 UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+                self?.setTriggered(for: Self.alertType(from: type), uuid: uuid)
             })
-
-            switch reason {
-            case .low:
-                switch type {
-                case .temperature:
-                    lowTemperatureAlerts[uuid] = Date()
-                case .relativeHumidity:
-                    lowRelativeHumidityAlerts[uuid] = Date()
-                case .humidity:
-                    lowHumidityAlerts[uuid] = Date()
-                case .pressure:
-                    lowPressureAlerts[uuid] = Date()
-                case .signal:
-                    lowSignalAlerts[uuid] = Date()
-                }
-            case .high:
-                switch type {
-                case .temperature:
-                    highTemperatureAlerts[uuid] = Date()
-                case .relativeHumidity:
-                    highRelativeHumidityAlerts[uuid] = Date()
-                case .humidity:
-                    highHumidityAlerts[uuid] = Date()
-                case .pressure:
-                    highPressureAlerts[uuid] = Date()
-                case .signal:
-                    highSignalAlerts[uuid] = Date()
-                }
-            }
         }
     }
 }
@@ -400,7 +316,7 @@ extension RuuviNotificationLocalImpl {
         }
     }
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    // swiftlint:disable:next cyclomatic_complexity
     private func startObserving() {
         alertDidChangeToken = NotificationCenter
             .default
@@ -421,32 +337,22 @@ extension RuuviNotificationLocalImpl {
                     if let uuid = physicalSensor?.luid?.value ?? physicalSensor?.macId?.value {
                         switch type {
                         case .temperature:
-                            self?.lowTemperatureAlerts[uuid] = nil
-                            self?.highTemperatureAlerts[uuid] = nil
                             if !isOn {
                                 self?.cancel(.temperature, for: uuid)
                             }
                         case .relativeHumidity:
-                            self?.lowRelativeHumidityAlerts[uuid] = nil
-                            self?.highRelativeHumidityAlerts[uuid] = nil
                             if !isOn {
                                 self?.cancel(.relativeHumidity, for: uuid)
                             }
                         case .humidity:
-                            self?.lowHumidityAlerts[uuid] = nil
-                            self?.highHumidityAlerts[uuid] = nil
                             if !isOn {
                                 self?.cancel(.humidity, for: uuid)
                             }
                         case .pressure:
-                            self?.lowPressureAlerts[uuid] = nil
-                            self?.highPressureAlerts[uuid] = nil
                             if !isOn {
                                 self?.cancel(.pressure, for: uuid)
                             }
                         case .signal:
-                            self?.lowSignalAlerts[uuid] = nil
-                            self?.highSignalAlerts[uuid] = nil
                             if !isOn {
                                 self?.cancel(.signal, for: uuid)
                             }
@@ -601,27 +507,13 @@ extension RuuviNotificationLocalImpl: UNUserNotificationCenterDelegate {
         else {
             assertionFailure(); return
         }
-        // TODO: @rinat go with sensors instead of pure uuid
-        let ruuviTag = RuuviTagSensorStruct(
-            version: 5,
-            firmwareVersion: nil,
-            luid: uuid.luid,
-            macId: uuid.mac,
-            isConnectable: true,
-            name: "",
-            isClaimed: false,
-            isOwner: false,
-            owner: nil,
-            ownersPlan: nil,
-            isCloudSensor: false,
-            canShare: false,
-            sharedTo: []
-        )
-        ruuviAlertService.mute(
-            type: Self.alertType(from: type),
-            for: ruuviTag,
-            till: date
-        )
+        ruuviStorage.readOne(uuid).on(success: { [weak self] ruuviTag in
+            self?.ruuviAlertService.mute(
+                type: Self.alertType(from: type),
+                for: ruuviTag,
+                till: date
+            )
+        })
     }
 
     private func mute(type: BlastNotificationType, uuid: String) {
@@ -629,27 +521,13 @@ extension RuuviNotificationLocalImpl: UNUserNotificationCenterDelegate {
         else {
             assertionFailure(); return
         }
-        // TODO: @rinat go with sensors instead of pure uuid
-        let ruuviTag = RuuviTagSensorStruct(
-            version: 5,
-            firmwareVersion: nil,
-            luid: uuid.luid,
-            macId: uuid.mac,
-            isConnectable: true,
-            name: "",
-            isClaimed: false,
-            isOwner: false,
-            owner: nil,
-            ownersPlan: nil,
-            isCloudSensor: false,
-            canShare: false,
-            sharedTo: []
-        )
-        ruuviAlertService.mute(
-            type: Self.alertType(from: type),
-            for: ruuviTag,
-            till: date
-        )
+        ruuviStorage.readOne(uuid).on(success: { [weak self] ruuviTag in
+            self?.ruuviAlertService.mute(
+                type: Self.alertType(from: type),
+                for: ruuviTag,
+                till: date
+            )
+        })
     }
 
     private func muteOffset() -> Date? {
@@ -660,10 +538,72 @@ extension RuuviNotificationLocalImpl: UNUserNotificationCenterDelegate {
         )
     }
 
-    private func lastTriggerOffset(from shown: Date) -> Date {
+    private func isMuted(
+        for type: AlertType,
+        uuid: String,
+        completion: @escaping (Bool) -> Void
+    ) {
+        ruuviStorage.readOne(uuid).on(success: { [weak self] ruuviTag in
+            guard let self = self else { return }
+            if let triggeredAt = self.ruuviAlertService.triggeredAt(for: ruuviTag, of: type),
+               let date = self.dateFormatter.date(from: triggeredAt) {
+                let intervalPassed = Date() > self.muteOffset(from: date)
+                self.evaluateMutedState(
+                    for: type,
+                    uuid: uuid,
+                    intervalPassed: intervalPassed,
+                    completion: completion
+                )
+            } else {
+                self.evaluateMutedState(
+                    for: type,
+                    uuid: uuid,
+                    intervalPassed: true,
+                    completion: completion
+                )
+            }
+        })
+    }
+
+    private func evaluateMutedState(
+        for type: AlertType, uuid: String,
+        intervalPassed: Bool,
+        completion: @escaping (Bool) -> Void
+    ) {
+        if let mutedTill = ruuviAlertService.mutedTill(type: type, for: uuid) {
+            completion(!(intervalPassed && mutedTill > Date()))
+        } else {
+            completion(!intervalPassed)
+        }
+    }
+
+    private func setTriggered(
+        for type: AlertType,
+        uuid: String
+    ) {
+        ruuviStorage.readOne(uuid).on(success: { [weak self] ruuviTag in
+            guard let sSelf = self else { return }
+            sSelf.ruuviAlertService.trigger(
+                type: type,
+                trigerred: true,
+                trigerredAt: sSelf.dateFormatter.string(from: Date()),
+                for: ruuviTag
+            )
+        })
+    }
+
+    /// Limit alert notification settings prevents new alerts within one hour
+    /// of last one. When the settings is off we still will prevent new notifications
+    /// based on save heartbeats background interval minutes (5mins).
+    /// When app is in foreground we save heartbeats every 2 seconds, but that's not
+    /// very user friendly to trigger notifications as that frequent alerts basically
+    /// makes app unusable by spamming. Besides, if user is in foreground they will
+    /// see the alert bells anyway.
+    private func muteOffset(from shown: Date) -> Date {
         Calendar.current.date(
             byAdding: .minute,
-            value: settings.alertsMuteIntervalMinutes,
+            value: settings.limitAlertNotificationsEnabled ?
+                settings.alertsMuteIntervalMinutes : settings.saveHeartbeatsIntervalMinutes,
             to: shown
         ) ?? Date()
     }
@@ -673,6 +613,13 @@ extension RuuviNotificationLocalImpl: UNUserNotificationCenterDelegate {
         let newBadgeCount = currentCount + 1
         content.badge = newBadgeCount as NSNumber
         settings.setNotificationsBadgeCount(value: newBadgeCount)
+    }
+
+    private func ruuviTag(
+        for uuid: String,
+        completion: @escaping(AnyRuuviTagSensor) -> Void
+    ) {
+        ruuviStorage.readOne(uuid).on(success: completion)
     }
 }
 

--- a/Packages/RuuviService/Sources/RuuviServiceAlert/AlertPersistence/UserDefaults/AlertPersistenceUserDefaults.swift
+++ b/Packages/RuuviService/Sources/RuuviServiceAlert/AlertPersistence/UserDefaults/AlertPersistenceUserDefaults.swift
@@ -92,6 +92,10 @@ class AlertPersistenceUserDefaults: AlertPersistence {
         = "AlertPersistenceUserDefaults.connectionAlertDescriptionUDKeyPrefix."
     private let connectionAlertMuteTillDateUDKeyPrefix
         = "AlertPersistenceUserDefaults.connectionAlertMuteTillDateUDKeyPrefix."
+    private let connectionAlertIsTriggeredUDKeyPrefix
+        = "AlertPersistenceUserDefaults.connectionAlertIsTriggeredUDKeyPrefix."
+    private let connectionAlertTriggeredAtUDKeyPrefix
+        = "AlertPersistenceUserDefaults.connectionAlertTriggeredAtUDKeyPrefix."
 
     // cloud connection
     private let cloudConnectionAlertIsOnUDKeyPrefix
@@ -385,7 +389,7 @@ class AlertPersistenceUserDefaults: AlertPersistence {
         switch type {
         case .temperature:
             prefs.set(trigerred, forKey: temperatureAlertIsTriggeredUDKeyPrefix + uuid)
-            prefs.set(trigerred, forKey: temperatureAlertTriggeredAtUDKeyPrefix + uuid)
+            prefs.set(trigerredAt, forKey: temperatureAlertTriggeredAtUDKeyPrefix + uuid)
         case .relativeHumidity:
             prefs.set(trigerred, forKey: relativeHumidityAlertIsTriggeredUDKeyPrefix + uuid)
             prefs.set(trigerredAt, forKey: relativeHumidityAlertTriggeredAtUDKeyPrefix + uuid)
@@ -405,7 +409,8 @@ class AlertPersistenceUserDefaults: AlertPersistence {
             prefs.set(trigerred, forKey: movementAlertIsTriggeredUDKeyPrefix + uuid)
             prefs.set(trigerredAt, forKey: movementAlertTriggeredAtUDKeyPrefix + uuid)
         case .connection:
-            break
+            prefs.set(trigerred, forKey: connectionAlertIsTriggeredUDKeyPrefix + uuid)
+            prefs.set(trigerredAt, forKey: connectionAlertTriggeredAtUDKeyPrefix + uuid)
         }
     }
 
@@ -426,7 +431,7 @@ class AlertPersistenceUserDefaults: AlertPersistence {
         case .movement:
             prefs.bool(forKey: movementAlertIsTriggeredUDKeyPrefix + uuid)
         case .connection:
-            nil
+            prefs.bool(forKey: connectionAlertIsTriggeredUDKeyPrefix + uuid)
         }
     }
 
@@ -447,7 +452,7 @@ class AlertPersistenceUserDefaults: AlertPersistence {
         case .movement:
             prefs.string(forKey: movementAlertTriggeredAtUDKeyPrefix + uuid)
         case .connection:
-            nil
+            prefs.string(forKey: connectionAlertTriggeredAtUDKeyPrefix + uuid)
         }
     }
 }


### PR DESCRIPTION
- Instead of class cache, last triggered alert details are now stored in user defaults and offset is calculated from there. 

- Move save heartbeats foreground interval to default instead of hardcoding.

- Remove hardcoding sensor struct from uuid/macid and getting appropriate RuuviTag from RuuviStorage.