### PR TITLE
Fix OTHER_SWIFT_FLAG

### DIFF
--- a/Apps/RuuviStation/target.yml
+++ b/Apps/RuuviStation/target.yml
@@ -100,7 +100,7 @@ targets:
           DEBUG_INFORMATION_FORMAT: "dwarf-with-dsym"
           OTHER_SWIFT_FLAGS:
           - $(inherited)
-          - -DALPHA=1
+          - -DALPHA
         Debug:
           CODE_SIGN_STYLE: Automatic
           OTHER_LDFLAGS: -ld_classic


### PR DESCRIPTION
fixes:
warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'ALPHA=1')