### PR TITLE
task: [Experiment] Offload history sync from sign in flow #2067

### DIFF
--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Charts/Assembly/TagChartsModuleFactory.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Charts/Assembly/TagChartsModuleFactory.swift
@@ -48,6 +48,7 @@ final class TagChartsModuleFactoryImpl: TagChartsModuleFactory {
         interactor.ruuviReactor = r.resolve(RuuviReactor.self)
         interactor.ruuviPool = r.resolve(RuuviPool.self)
         interactor.ruuviStorage = r.resolve(RuuviStorage.self)
+        interactor.cloudSyncService = r.resolve(RuuviServiceCloudSync.self)
         interactor.ruuviSensorRecords = r.resolve(RuuviServiceSensorRecords.self)
         interactor.featureToggleService = r.resolve(FeatureToggleService.self)
         interactor.localSyncState = r.resolve(RuuviLocalSyncState.self)

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Home/Assembly/DashboardModuleFactory.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Home/Assembly/DashboardModuleFactory.swift
@@ -56,6 +56,7 @@ final class DashboardModuleFactoryImpl: DashboardModuleFactory {
         presenter.authService = r.resolve(RuuviServiceAuth.self)
         presenter.pnManager = r.resolve(RuuviCorePN.self)
         presenter.cloudNotificationService = r.resolve(RuuviServiceCloudNotification.self)
+        presenter.cloudSyncService = r.resolve(RuuviServiceCloudSync.self)
         router.delegate = presenter
 
         let interactor = DashboardInteractor()

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Home/Presenter/DashboardPresenter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Home/Presenter/DashboardPresenter.swift
@@ -50,6 +50,7 @@ class DashboardPresenter: DashboardModuleInput {
     var activityPresenter: ActivityPresenter!
     var pnManager: RuuviCorePN!
     var cloudNotificationService: RuuviServiceCloudNotification!
+    var cloudSyncService: RuuviServiceCloudSync!
     private var ruuviTagToken: RuuviReactorToken?
     private var ruuviTagObserveLastRecordTokens = [RuuviReactorToken]()
     private var advertisementTokens = [ObservationToken]()
@@ -159,6 +160,7 @@ extension DashboardPresenter: DashboardViewOutput {
         startObservingCloudSyncSuccessTokenState()
         startObservingCloudSyncFailTokenState()
         startObservingSensorOrderChanges()
+        triggerFullHistorySync()
         pushNotificationsManager.registerForRemoteNotifications()
     }
 
@@ -422,6 +424,7 @@ extension DashboardPresenter: SignInBenefitsModuleOutput {
         module: SignInBenefitsModuleInput,
         didSuccessfulyLogin _: Any?
     ) {
+        triggerFullHistorySync()
         startObservingRuuviTags()
         startObservingCloudModeNotification()
         module.dismiss(completion: {
@@ -1971,6 +1974,14 @@ extension DashboardPresenter {
 
     private func dashboardSortingType() -> DashboardSortingType {
         return settings.dashboardSensorOrder.count == 0 ? .alphabetical : .manual
+    }
+
+    private func triggerFullHistorySync() {
+        if settings.historySyncOnDashboard &&
+            (!settings.historySyncLegacy ||
+             !settings.historySyncForEachSensor) {
+            cloudSyncService.syncAllHistory()
+        }
     }
 }
 

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Settings/Submodules/Defaults/Presenter/DefaultsPresenter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Settings/Submodules/Defaults/Presenter/DefaultsPresenter.swift
@@ -67,6 +67,9 @@ extension DefaultsPresenter {
             buildShowStatusLabelSettings(),
             buildShowAlertRangeInGraph(),
             buildUseNewChartsRendering(),
+            buildDoIndividualHistorySync(),
+            buildDoLegacyHistorySync(),
+            buildDoHistorySyncAfterSignIn(),
         ]
     }
 
@@ -412,6 +415,48 @@ extension DefaultsPresenter {
 
         bind(viewModel.boolean, fire: false) { observer, show in
             observer.settings.useNewGraphRendering = GlobalHelpers.getBool(from: show)
+        }
+
+        return viewModel
+    }
+
+    private func buildDoHistorySyncAfterSignIn() -> DefaultsViewModel {
+        let viewModel = DefaultsViewModel()
+        viewModel.title = RuuviLocalization.Defaults.HistorySyncDashboard.title
+        viewModel.boolean.value = settings.historySyncOnDashboard
+        viewModel.hideStatusLabel.value = !settings.showSwitchStatusLabel
+        viewModel.type.value = .switcher
+
+        bind(viewModel.boolean, fire: false) { observer, bool in
+            observer.settings.historySyncLegacy = GlobalHelpers.getBool(from: bool)
+        }
+
+        return viewModel
+    }
+
+    private func buildDoIndividualHistorySync() -> DefaultsViewModel {
+        let viewModel = DefaultsViewModel()
+        viewModel.title = RuuviLocalization.Defaults.HistorySyncPerSensor.title
+        viewModel.boolean.value = settings.historySyncForEachSensor
+        viewModel.hideStatusLabel.value = !settings.showSwitchStatusLabel
+        viewModel.type.value = .switcher
+
+        bind(viewModel.boolean, fire: false) { observer, bool in
+            observer.settings.historySyncOnDashboard = GlobalHelpers.getBool(from: bool)
+        }
+
+        return viewModel
+    }
+
+    private func buildDoLegacyHistorySync() -> DefaultsViewModel {
+        let viewModel = DefaultsViewModel()
+        viewModel.title = RuuviLocalization.Defaults.HistorySyncLegacy.title
+        viewModel.boolean.value = settings.historySyncLegacy
+        viewModel.hideStatusLabel.value = !settings.showSwitchStatusLabel
+        viewModel.type.value = .switcher
+
+        bind(viewModel.boolean, fire: false) { observer, bool in
+            observer.settings.historySyncForEachSensor = GlobalHelpers.getBool(from: bool)
         }
 
         return viewModel

--- a/Packages/RuuviCloud/Sources/RuuviCloudApi/URLSession/Models/Response/RuuviCloudApiUserResponse.swift
+++ b/Packages/RuuviCloud/Sources/RuuviCloudApi/URLSession/Models/Response/RuuviCloudApiUserResponse.swift
@@ -84,6 +84,10 @@ extension RuuviCloudApiSensor: CloudSensor {
         []
     }
 
+    public var maxHistoryDays: Int? {
+        nil
+    }
+
     /// Returns the 'id' of the sensor
     public var id: String {
         sensorId

--- a/Packages/RuuviCloud/Sources/RuuviCloudPure/RuuviCloudPure.swift
+++ b/Packages/RuuviCloud/Sources/RuuviCloudPure/RuuviCloudPure.swift
@@ -818,7 +818,8 @@ public final class RuuviCloudPure: RuuviCloud {
                             offsetPressure: sensor.offsetPressure,
                             isCloudSensor: true,
                             canShare: sensor.canShare,
-                            sharedTo: sensor.sharedTo ?? []
+                            sharedTo: sensor.sharedTo ?? [],
+                            maxHistoryDays: sensor.subscription?.maxHistoryDays
                         ),
                         record: self?.decodeSensorRecord(
                             macId: sensor.sensor.mac,

--- a/Packages/RuuviContext/Sources/RuuviContextSQLite/SQLiteContextGRDB.swift
+++ b/Packages/RuuviContext/Sources/RuuviContextSQLite/SQLiteContextGRDB.swift
@@ -65,7 +65,7 @@ extension SQLiteGRDBDatabase {
         }
     }
 
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func migrate(dbPool: DatabasePool) throws {
         var migrator = GRDB.DatabaseMigrator()
 
@@ -205,6 +205,17 @@ extension SQLiteGRDBDatabase {
             }
             try db.alter(table: RuuviTagSQLite.databaseTableName, body: { t in
                 t.add(column: RuuviTagSQLite.ownersPlan.name, .text)
+            })
+        }
+        // v12
+        migrator.registerMigration("Create RuuviTagSQLite maxHistoryDays column") { db in
+            guard try db.columns(in: RuuviTagSQLite.databaseTableName)
+                .contains(where: { $0.name == RuuviTagSQLite.maxHistoryDaysColumn.name }) == false
+            else {
+                return
+            }
+            try db.alter(table: RuuviTagSQLite.databaseTableName, body: { t in
+                t.add(column: RuuviTagSQLite.maxHistoryDaysColumn.name, .integer)
             })
         }
 

--- a/Packages/RuuviDaemon/Sources/RuuviDaemonRuuviTag/Properties/RuuviTagPropertiesDaemonBTKit.swift
+++ b/Packages/RuuviDaemon/Sources/RuuviDaemonRuuviTag/Properties/RuuviTagPropertiesDaemonBTKit.swift
@@ -224,7 +224,8 @@ public final class RuuviTagPropertiesDaemonBTKit: RuuviDaemonWorker, RuuviTagPro
                 ownersPlan: ruuviTag.ownersPlan,
                 isCloudSensor: ruuviTag.isCloudSensor,
                 canShare: ruuviTag.canShare,
-                sharedTo: ruuviTag.sharedTo
+                sharedTo: ruuviTag.sharedTo,
+                maxHistoryDays: ruuviTag.maxHistoryDays
             )
             sSelf.idPersistence.set(mac: mac, for: device.uuid.luid)
             sSelf.idPersistence.set(luid: device.uuid.luid, for: mac)

--- a/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalSettings.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalSettings.swift
@@ -98,6 +98,17 @@ public protocol RuuviLocalSettings {
     var showAlertsRangeInGraph: Bool { get set }
     var useNewGraphRendering: Bool { get set }
 
+    /// Syncs full history for all sensoers after code verification
+    /// on sign in, before presenting dashboard. Heavy after sign in
+    /// specially if the connection is poor.
+    var historySyncLegacy: Bool { get set }
+    /// Syncs full history for all sensors after sign in is completed
+    /// and user lands on dashboard. Heavy and can cause lag on dashboard.
+    var historySyncOnDashboard: Bool { get set }
+    /// Syncs full history for each sensor when associated charts
+    /// is presented. Much efficient.
+    var historySyncForEachSensor: Bool { get set }
+
     var customTempAlertLowerBound: Double { get set }
     var customTempAlertUpperBound: Double { get set }
 

--- a/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalSettingsUserDefaults.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalSettingsUserDefaults.swift
@@ -728,6 +728,13 @@ final class RuuviLocalSettingsUserDefaults: RuuviLocalSettings {
     var showAlertsRangeInGraph: Bool
     @UserDefault("SettingsUserDefaults.useNewGraphRendering", defaultValue: false)
     var useNewGraphRendering: Bool
+
+    @UserDefault("SettingsUserDefaults.historySyncLegacy", defaultValue: false)
+    var historySyncLegacy: Bool
+    @UserDefault("SettingsUserDefaults.historySyncOnDashboard", defaultValue: false)
+    var historySyncOnDashboard: Bool
+    @UserDefault("SettingsUserDefaults.historySyncForEachSensor", defaultValue: true)
+    var historySyncForEachSensor: Bool
 }
 
 // swiftlint:enable type_body_length file_length

--- a/Packages/RuuviNotification/Sources/RuuviNotificationLocal/RuuviNotificationLocalImpl.swift
+++ b/Packages/RuuviNotification/Sources/RuuviNotificationLocal/RuuviNotificationLocalImpl.swift
@@ -436,7 +436,8 @@ extension RuuviNotificationLocalImpl: UNUserNotificationCenterDelegate {
                     ownersPlan: nil,
                     isCloudSensor: false,
                     canShare: false,
-                    sharedTo: []
+                    sharedTo: [],
+                    maxHistoryDays: nil
                 )
                 ruuviAlertService.unregister(type: Self.alertType(from: type), ruuviTag: ruuviTag)
             case lowHigh.mute:
@@ -463,7 +464,8 @@ extension RuuviNotificationLocalImpl: UNUserNotificationCenterDelegate {
                     ownersPlan: nil,
                     isCloudSensor: false,
                     canShare: false,
-                    sharedTo: []
+                    sharedTo: [],
+                    maxHistoryDays: nil
                 )
                 ruuviAlertService.unregister(type: Self.alertType(from: type), ruuviTag: ruuviTag)
             case blast.mute:

--- a/Packages/RuuviOntology/Sources/RuuviOntology/Mappers/RuuviTag+RuuviTagSensor.swift
+++ b/Packages/RuuviOntology/Sources/RuuviOntology/Mappers/RuuviTag+RuuviTagSensor.swift
@@ -16,7 +16,8 @@ public extension RuuviTag {
             ownersPlan: nil,
             isCloudSensor: false,
             canShare: false,
-            sharedTo: []
+            sharedTo: [],
+            maxHistoryDays: nil
         )
     }
 }

--- a/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/CloudSensor.swift
+++ b/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/CloudSensor.swift
@@ -15,7 +15,8 @@ public extension CloudSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -33,7 +34,8 @@ public extension CloudSensor {
             offsetPressure: offsetPressure,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 }
@@ -52,6 +54,7 @@ public struct CloudSensorStruct: CloudSensor {
     public var canShare: Bool
     public var sharedTo: [String]
     public var ownersPlan: String?
+    public var maxHistoryDays: Int?
 
     public init(
         id: String,
@@ -66,7 +69,8 @@ public struct CloudSensorStruct: CloudSensor {
         offsetPressure: Double?,
         isCloudSensor: Bool?,
         canShare: Bool,
-        sharedTo: [String]
+        sharedTo: [String],
+        maxHistoryDays: Int?
     ) {
         self.id = id
         self.name = name
@@ -81,6 +85,7 @@ public struct CloudSensorStruct: CloudSensor {
         self.isCloudSensor = isCloudSensor
         self.canShare = canShare
         self.sharedTo = sharedTo
+        self.maxHistoryDays = maxHistoryDays
     }
 }
 
@@ -147,6 +152,10 @@ public struct AnyCloudSensor: CloudSensor, Equatable, Hashable, Reorderable {
 
     public var sharedTo: [String] {
         object.sharedTo
+    }
+
+    public var maxHistoryDays: Int? {
+        object.maxHistoryDays
     }
 
     public static func == (lhs: AnyCloudSensor, rhs: AnyCloudSensor) -> Bool {

--- a/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/CloudSensorDense.swift
+++ b/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/CloudSensorDense.swift
@@ -86,6 +86,10 @@ public struct AnyCloudSensorDense: CloudSensor, Equatable, Hashable, Reorderable
         sensor.sharedTo
     }
 
+    public var maxHistoryDays: Int? {
+        subscription?.maxHistoryDays
+    }
+
     public static func == (lhs: AnyCloudSensorDense, rhs: AnyCloudSensorDense) -> Bool {
         lhs.id == rhs.id
     }

--- a/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/RuuviTag/RuuviTagSensor.swift
+++ b/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/RuuviTag/RuuviTagSensor.swift
@@ -1,7 +1,13 @@
 // swiftlint:disable file_length
 import Foundation
 
-public protocol RuuviTagSensor: PhysicalSensor, Versionable, Claimable, Connectable, Nameable, Shareable {}
+public protocol RuuviTagSensor: PhysicalSensor,
+                                Versionable,
+                                Claimable,
+                                Connectable,
+                                Nameable,
+                                Shareable,
+                                HistoryFetchable {}
 
 public enum SensorOwnership {
     case claimedByMe
@@ -53,7 +59,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -71,7 +78,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -89,7 +97,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -107,7 +116,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -125,7 +135,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -143,7 +154,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -161,7 +173,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -179,7 +192,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -197,7 +211,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -215,7 +230,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -233,7 +249,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -251,7 +268,8 @@ public extension RuuviTagSensor {
             ownersPlan: nil,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -269,7 +287,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -287,7 +306,8 @@ public extension RuuviTagSensor {
             ownersPlan: cloudSensor.ownersPlan,
             isCloudSensor: cloudSensor.isCloudSensor ?? true,
             canShare: cloudSensor.canShare,
-            sharedTo: cloudSensor.sharedTo
+            sharedTo: cloudSensor.sharedTo,
+            maxHistoryDays: cloudSensor.maxHistoryDays
         )
         return sensor
     }
@@ -306,7 +326,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -324,7 +345,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: false,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -342,7 +364,8 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -360,7 +383,27 @@ public extension RuuviTagSensor {
             ownersPlan: ownersPlan,
             isCloudSensor: isCloudSensor,
             canShare: canShare,
-            sharedTo: sharedTo
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
+        )
+    }
+
+    func with(maxHistoryDays: Int) -> RuuviTagSensor {
+        RuuviTagSensorStruct(
+            version: version,
+            firmwareVersion: firmwareVersion,
+            luid: luid,
+            macId: macId,
+            isConnectable: isConnectable,
+            name: name,
+            isClaimed: isClaimed,
+            isOwner: isOwner,
+            owner: owner,
+            ownersPlan: ownersPlan,
+            isCloudSensor: isCloudSensor,
+            canShare: canShare,
+            sharedTo: sharedTo,
+            maxHistoryDays: maxHistoryDays
         )
     }
 
@@ -385,6 +428,7 @@ public struct RuuviTagSensorStruct: RuuviTagSensor {
     public var isCloudSensor: Bool?
     public var canShare: Bool
     public var sharedTo: [String]
+    public var maxHistoryDays: Int?
 
     public init(
         version: Int,
@@ -399,7 +443,8 @@ public struct RuuviTagSensorStruct: RuuviTagSensor {
         ownersPlan: String?,
         isCloudSensor: Bool?,
         canShare: Bool,
-        sharedTo: [String]
+        sharedTo: [String],
+        maxHistoryDays: Int?
     ) {
         self.version = version
         self.firmwareVersion = firmwareVersion
@@ -414,6 +459,7 @@ public struct RuuviTagSensorStruct: RuuviTagSensor {
         self.isCloudSensor = isCloudSensor
         self.canShare = canShare
         self.sharedTo = sharedTo
+        self.maxHistoryDays = maxHistoryDays
     }
 }
 
@@ -480,6 +526,10 @@ public struct AnyRuuviTagSensor: RuuviTagSensor, Equatable, Hashable, Reorderabl
         object.sharedTo.filter {
             !$0.isEmpty
         }
+    }
+
+    public var maxHistoryDays: Int? {
+        object.maxHistoryDays
     }
 
     public static func == (lhs: AnyRuuviTagSensor, rhs: AnyRuuviTagSensor) -> Bool {

--- a/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/Sensor.swift
+++ b/Packages/RuuviOntology/Sources/RuuviOntology/Sensor/Sensor.swift
@@ -41,11 +41,21 @@ public protocol Calibratable {
     var offsetPressure: Double? { get } // in hPa
 }
 
-public protocol CloudSensor: Sensor, Nameable, Claimable, HasRemotePicture, Calibratable, Shareable {}
+public protocol CloudSensor: Sensor,
+                             Nameable,
+                             Claimable,
+                             HasRemotePicture,
+                             Calibratable,
+                             Shareable,
+                             HistoryFetchable {}
 
 public protocol Shareable {
     var canShare: Bool { get }
     var sharedTo: [String] { get } // emails
+}
+
+public protocol HistoryFetchable {
+    var maxHistoryDays: Int? { get }
 }
 
 public protocol ShareableSensor: Sensor, Shareable {}

--- a/Packages/RuuviOntology/Sources/RuuviOntologySQLite/RuuviTagSQLite.swift
+++ b/Packages/RuuviOntology/Sources/RuuviOntologySQLite/RuuviTagSQLite.swift
@@ -16,6 +16,7 @@ public struct RuuviTagSQLite: RuuviTagSensor, Equatable {
     public var isCloudSensor: Bool?
     public var canShare: Bool
     public var sharedTo: [String]
+    public var maxHistoryDays: Int?
 
     public init(
         id: String,
@@ -31,7 +32,8 @@ public struct RuuviTagSQLite: RuuviTagSensor, Equatable {
         ownersPlan: String?,
         isCloudSensor: Bool?,
         canShare: Bool,
-        sharedTo: [String]
+        sharedTo: [String],
+        maxHistoryDays: Int?
     ) {
         self.id = id
         self.macId = macId
@@ -47,6 +49,7 @@ public struct RuuviTagSQLite: RuuviTagSensor, Equatable {
         self.isCloudSensor = isCloudSensor
         self.canShare = canShare
         self.sharedTo = sharedTo
+        self.maxHistoryDays = maxHistoryDays
     }
 
     public static func == (lhs: RuuviTagSQLite, rhs: RuuviTagSQLite) -> Bool {
@@ -64,6 +67,7 @@ public struct RuuviTagSQLite: RuuviTagSensor, Equatable {
         && lhs.isCloudSensor == rhs.isCloudSensor
         && lhs.canShare == rhs.canShare
         && lhs.sharedTo == rhs.sharedTo
+        && lhs.maxHistoryDays == rhs.maxHistoryDays
     }
 }
 
@@ -83,6 +87,7 @@ public extension RuuviTagSQLite {
     static let isCloudSensor = Column("isCloudSensor")
     static let canShareColumn = Column("canShare")
     static let sharedToColumn = Column("sharedTo")
+    static let maxHistoryDaysColumn = Column("maxHistoryDays")
 }
 
 extension RuuviTagSQLite: FetchableRecord {
@@ -104,6 +109,7 @@ extension RuuviTagSQLite: FetchableRecord {
         ownersPlan = row[RuuviTagSQLite.ownersPlan]
         isCloudSensor = row[RuuviTagSQLite.isCloudSensor]
         canShare = row[RuuviTagSQLite.canShareColumn]
+        maxHistoryDays = row[RuuviTagSQLite.maxHistoryDaysColumn]
         if let sharedToColumn = row[RuuviTagSQLite.sharedToColumn] as? String {
             sharedTo = sharedToColumn.components(separatedBy: ",")
         } else {
@@ -132,6 +138,7 @@ extension RuuviTagSQLite: PersistableRecord {
         container[RuuviTagSQLite.isCloudSensor] = isCloudSensor
         container[RuuviTagSQLite.canShareColumn] = canShare
         container[RuuviTagSQLite.sharedToColumn] = sharedTo.joined(separator: ",")
+        container[RuuviTagSQLite.maxHistoryDaysColumn] = maxHistoryDays
     }
 }
 
@@ -156,6 +163,7 @@ public extension RuuviTagSQLite {
             table.column(RuuviTagSQLite.isCloudSensor.name, .boolean)
             table.column(RuuviTagSQLite.canShareColumn.name, .boolean)
             table.column(RuuviTagSQLite.sharedToColumn.name, .text)
+            table.column(RuuviTagSQLite.maxHistoryDaysColumn.name, .integer)
         })
     }
 }

--- a/Packages/RuuviPersistence/Sources/RuuviPersistenceSQLite/RuuviPersistenceSQLite.swift
+++ b/Packages/RuuviPersistence/Sources/RuuviPersistenceSQLite/RuuviPersistenceSQLite.swift
@@ -45,7 +45,8 @@ public class RuuviPersistenceSQLite: RuuviPersistence, DatabaseService {
             ownersPlan: ruuviTag.ownersPlan,
             isCloudSensor: ruuviTag.isCloudSensor,
             canShare: ruuviTag.canShare,
-            sharedTo: ruuviTag.sharedTo
+            sharedTo: ruuviTag.sharedTo,
+            maxHistoryDays: ruuviTag.maxHistoryDays
         )
         do {
             try database.dbPool.write { db in
@@ -402,7 +403,8 @@ public class RuuviPersistenceSQLite: RuuviPersistence, DatabaseService {
             ownersPlan: ruuviTag.ownersPlan,
             isCloudSensor: ruuviTag.isCloudSensor,
             canShare: ruuviTag.canShare,
-            sharedTo: ruuviTag.sharedTo
+            sharedTo: ruuviTag.sharedTo,
+            maxHistoryDays: ruuviTag.maxHistoryDays
         )
 
         do {
@@ -433,7 +435,8 @@ public class RuuviPersistenceSQLite: RuuviPersistence, DatabaseService {
             ownersPlan: ruuviTag.ownersPlan,
             isCloudSensor: ruuviTag.isCloudSensor,
             canShare: ruuviTag.canShare,
-            sharedTo: ruuviTag.sharedTo
+            sharedTo: ruuviTag.sharedTo,
+            maxHistoryDays: ruuviTag.maxHistoryDays
         )
         do {
             var success = false

--- a/Packages/RuuviService/Sources/RuuviService/RuuviServiceCloudSync.swift
+++ b/Packages/RuuviService/Sources/RuuviService/RuuviServiceCloudSync.swift
@@ -10,6 +10,9 @@ public protocol RuuviServiceCloudSync {
     func sync(sensor: RuuviTagSensor) -> Future<[AnyRuuviTagSensorRecord], RuuviServiceError>
 
     @discardableResult
+    func syncAllHistory() -> Future<Bool, RuuviServiceError>
+
+    @discardableResult
     func refreshLatestRecord() -> Future<Bool, RuuviServiceError>
 
     @discardableResult


### PR DESCRIPTION
- Default behaviour is do history sync when user opens history page.
- Added two extra flag for enabling history sync on sign in flow, or after dashboard is visible.
- The flags are mutually exclusive but better to turn the other ones disabled and keep the intended one enabled.