### PR TITLE
fix: Use fixed refresh interval for widgets #1545

### DIFF
--- a/Apps/RuuviStation/Sources/Classes/Application/AppGroupConstants.swift
+++ b/Apps/RuuviStation/Sources/Classes/Application/AppGroupConstants.swift
@@ -12,4 +12,6 @@ enum AppGroupConstants {
     static let pressureUnitKey = "pressureUnitKey"
     static let pressureAccuracyKey = "pressureAccuracyKey"
     static let useDevServerKey = "useDevServerKey"
+    static let widgetRefreshIntervalKey = "widgetRefreshIntervalKey"
+    static let forceRefreshWidgetKey = "forceRefreshWidgetKey"
 }

--- a/Apps/RuuviStation/Sources/Classes/Application/AppState/Impl/AppStateServiceImpl.swift
+++ b/Apps/RuuviStation/Sources/Classes/Application/AppState/Impl/AppStateServiceImpl.swift
@@ -19,6 +19,10 @@ class AppStateServiceImpl: AppStateService {
     var userPropertiesService: RuuviAnalytics!
     var universalLinkCoordinator: UniversalLinkCoordinator!
 
+    private let appGroupDefaults = UserDefaults(
+        suiteName: AppGroupConstants.appGroupSuiteIdentifier
+    )
+
     func application(
         _: UIApplication,
         didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
@@ -61,7 +65,15 @@ class AppStateServiceImpl: AppStateService {
         if ruuviUser.isAuthorized {
             cloudSyncDaemon.stop()
 #if canImport(WidgetKit)
-            WidgetCenter.shared.reloadTimelines(ofKind: AppAssemblyConstants.simpleWidgetKindId)
+            // Refresh widgets regardless of interval if user moves the app
+            // to background.
+            appGroupDefaults?.set(
+                true,
+                forKey: AppGroupConstants.forceRefreshWidgetKey
+            )
+            WidgetCenter.shared.reloadTimelines(
+                ofKind: AppAssemblyConstants.simpleWidgetKindId
+            )
 #endif
         }
         propertiesDaemon.stop()

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Home/Presenter/DashboardPresenter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Dashboard/Home/Presenter/DashboardPresenter.swift
@@ -78,6 +78,7 @@ class DashboardPresenter: DashboardModuleInput {
     private var pressureUnitToken: NSObjectProtocol?
     private var pressureAccuracyToken: NSObjectProtocol?
     private var languageToken: NSObjectProtocol?
+    private var widgetRefreshIntervalToken: NSObjectProtocol?
     private var systemLanguageChangeToken: NSObjectProtocol?
     private var calibrationSettingsToken: NSObjectProtocol?
     private var dashboardTypeToken: NSObjectProtocol?
@@ -129,6 +130,7 @@ class DashboardPresenter: DashboardModuleInput {
         pressureUnitToken?.invalidate()
         pressureAccuracyToken?.invalidate()
         languageToken?.invalidate()
+        widgetRefreshIntervalToken?.invalidate()
         systemLanguageChangeToken?.invalidate()
         calibrationSettingsToken?.invalidate()
         dashboardTypeToken?.invalidate()
@@ -751,6 +753,7 @@ extension DashboardPresenter {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     private func syncAppSettingsToAppGroupContainer() {
         appGroupDefaults?.set(
             ruuviUser.isAuthorized,
@@ -806,6 +809,17 @@ extension DashboardPresenter {
         appGroupDefaults?.set(
             settings.pressureAccuracy.value,
             forKey: AppGroupConstants.pressureAccuracyKey
+        )
+
+        // Widget refresh interval
+        appGroupDefaults?.set(
+            settings.widgetRefreshIntervalMinutes,
+            forKey: AppGroupConstants.widgetRefreshIntervalKey
+        )
+
+        appGroupDefaults?.set(
+            settings.forceRefreshWidget,
+            forKey: AppGroupConstants.forceRefreshWidgetKey
         )
 
         // Reload widget
@@ -1501,6 +1515,16 @@ extension DashboardPresenter {
             .default
             .addObserver(
                 forName: .LanguageDidChange,
+                object: nil,
+                queue: .main,
+                using: { [weak self] _ in
+                    self?.syncAppSettingsToAppGroupContainer()
+                }
+            )        
+        widgetRefreshIntervalToken = NotificationCenter
+            .default
+            .addObserver(
+                forName: .WidgetRefreshIntervalDidChange,
                 object: nil,
                 queue: .main,
                 using: { [weak self] _ in

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Settings/Submodules/Defaults/Presenter/DefaultsPresenter.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Settings/Submodules/Defaults/Presenter/DefaultsPresenter.swift
@@ -49,6 +49,8 @@ extension DefaultsPresenter {
             buildCardsSwipeHint(),
             buildAlertsMuteInterval(),
             buildWebPullInterval(),
+            buildNetworkPullingInterval(),
+            buildWidgetRefreshInterval(),
             buildPruningOffsetHours(),
             buildChartIntervalSeconds(),
             buildChartDurationHours(),
@@ -181,6 +183,32 @@ extension DefaultsPresenter {
             observer.settings.webPullIntervalMinutes = webPullInterval.bound
         }
         return webPullInterval
+    }
+
+    private func buildNetworkPullingInterval() -> DefaultsViewModel {
+        let viewModel = DefaultsViewModel()
+        viewModel.title = RuuviLocalization.Defaults.NetworkPullingInterval.title
+        viewModel.integer.value = settings.networkPullIntervalSeconds
+        viewModel.unit = .seconds
+        viewModel.type.value = .stepper
+
+        bind(viewModel.integer, fire: false) { observer, interval in
+            observer.settings.networkPullIntervalSeconds = interval.bound
+        }
+        return viewModel
+    }
+
+    private func buildWidgetRefreshInterval() -> DefaultsViewModel {
+        let viewModel = DefaultsViewModel()
+        viewModel.title = RuuviLocalization.Defaults.WidgetsRefreshInterval.title
+        viewModel.integer.value = settings.widgetRefreshIntervalMinutes
+        viewModel.unit = .minutes
+        viewModel.type.value = .stepper
+
+        bind(viewModel.integer, fire: false) { observer, interval in
+            observer.settings.widgetRefreshIntervalMinutes = interval.bound
+        }
+        return viewModel
     }
 
     private func buildPruningOffsetHours() -> DefaultsViewModel {

--- a/Apps/RuuviStation/Widgets/Sources/Helper/Constants.swift
+++ b/Apps/RuuviStation/Widgets/Sources/Helper/Constants.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum Constants: String {
     case appGroupBundleId = "group.com.ruuvi.station.widgets"
+    case queue = "com.ruuvi.station.widgets.userDefaultsQueue"
 
     case ruuviCloudBaseURL = "https://network.ruuvi.com"
     case ruuviCloudBaseURLDev = "https://j9ul2pfmol.execute-api.eu-central-1.amazonaws.com"
@@ -19,6 +20,8 @@ public enum Constants: String {
     case pressureUnitKey
     case pressureAccuracyKey
     case useDevServerKey
+    case widgetRefreshIntervalKey
+    case forceRefreshWidgetKey
 
     case ruuviLogo = "ruuvi_logo"
     case ruuviLogoEye = "eye_circle"

--- a/Apps/RuuviStation/Widgets/Sources/Helper/WidgetRefresher.swift
+++ b/Apps/RuuviStation/Widgets/Sources/Helper/WidgetRefresher.swift
@@ -1,0 +1,13 @@
+import AppIntents
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+struct WidgetRefresher: AppIntent {
+    static var title = LocalizedStringResource("Widgets.Refresh.Manual.title")
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let viewModel = WidgetViewModel()
+        viewModel.foceRefreshWidget(true)
+        return .result()
+    }
+}

--- a/Apps/RuuviStation/Widgets/Sources/Model/WidgetEntry.swift
+++ b/Apps/RuuviStation/Widgets/Sources/Model/WidgetEntry.swift
@@ -5,6 +5,7 @@ import WidgetKit
 struct WidgetEntry: TimelineEntry {
     let date: Date
     let isAuthorized: Bool
+    let isPreview: Bool
     let tag: RuuviWidgetTag
     let record: RuuviTagSensorRecord?
     let settings: SensorSettings?
@@ -16,6 +17,7 @@ extension WidgetEntry {
         WidgetEntry(
             date: Date(),
             isAuthorized: true,
+            isPreview: true,
             tag: .preview,
             record: RuuviTagSensorRecordStruct.preview(),
             settings: nil,
@@ -27,6 +29,7 @@ extension WidgetEntry {
         WidgetEntry(
             date: Date(),
             isAuthorized: false,
+            isPreview: false,
             tag: .preview,
             record: nil,
             settings: nil,
@@ -38,6 +41,7 @@ extension WidgetEntry {
         WidgetEntry(
             date: Date(),
             isAuthorized: true,
+            isPreview: false,
             tag: .preview,
             record: nil,
             settings: nil,
@@ -52,6 +56,7 @@ extension WidgetEntry {
         WidgetEntry(
             date: Date(),
             isAuthorized: authorized,
+            isPreview: false,
             tag: .preview,
             record: nil,
             settings: nil,

--- a/Apps/RuuviStation/Widgets/Sources/View/SimpleWidgetView.swift
+++ b/Apps/RuuviStation/Widgets/Sources/View/SimpleWidgetView.swift
@@ -15,12 +15,7 @@ struct SimpleWidgetView: View {
                         .frame(width: geometry.size.width * 0.35, alignment: .leading)
                         .foregroundColor(Color.logoColor)
                     Spacer()
-                    if #available(iOSApplicationExtension 17.0, *) {
-                        measurementTimeView(for: entry)
-                            .invalidatableContent()
-                    } else {
-                        measurementTimeView(for: entry)
-                    }
+                    measurementTimeView(for: entry)
                 }.padding(EdgeInsets(top: 12, leading: 12, bottom: 0, trailing: 12))
 
                 Spacer()

--- a/Apps/RuuviStation/Widgets/Sources/View/SimpleWidgetView.swift
+++ b/Apps/RuuviStation/Widgets/Sources/View/SimpleWidgetView.swift
@@ -15,19 +15,17 @@ struct SimpleWidgetView: View {
                         .frame(width: geometry.size.width * 0.35, alignment: .leading)
                         .foregroundColor(Color.logoColor)
                     Spacer()
-                    Text(viewModel.measurementTime(from: entry))
-                        .foregroundColor(Color.sensorNameColor1)
-                        .font(.custom(
-                            Constants.muliRegular.rawValue,
-                            size: canShowBackground ? 10 : 14,
-                            relativeTo: .body
-                        ))
-                        .minimumScaleFactor(0.5)
+                    if #available(iOSApplicationExtension 17.0, *) {
+                        measurementTimeView(for: entry)
+                            .invalidatableContent()
+                    } else {
+                        measurementTimeView(for: entry)
+                    }
                 }.padding(EdgeInsets(top: 12, leading: 12, bottom: 0, trailing: 12))
 
                 Spacer()
 
-                VStack {
+                VStack(spacing: 4) {
                     HStack {
                         Text(entry.tag.displayString)
                             .foregroundColor(Color.sensorNameColor1)
@@ -37,7 +35,7 @@ struct SimpleWidgetView: View {
                                 relativeTo: .headline
                             )
                             )
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .frame(maxWidth: .infinity, alignment: .bottomLeading)
                             .fixedSize(horizontal: false, vertical: true)
                             .minimumScaleFactor(0.5)
                     }
@@ -55,6 +53,7 @@ struct SimpleWidgetView: View {
                             size: canShowBackground ? 36 : 66,
                             relativeTo: .largeTitle
                         ))
+                        .frame(maxWidth: .infinity, alignment: .bottomLeading)
                         .minimumScaleFactor(0.5)
                         Text(viewModel.getUnit(for: WidgetSensorEnum(rawValue: entry.config.sensor.rawValue)))
                             .foregroundColor(Color.unitTextColor)
@@ -64,12 +63,38 @@ struct SimpleWidgetView: View {
                                 relativeTo: .title3
                             ))
                             .baselineOffset(14)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                             .minimumScaleFactor(0.5)
-                        Spacer()
+                        if #available(iOS 17.0, *) {
+                            if !entry.isPreview {
+                                Button(intent: WidgetRefresher()
+                                ) {
+                                    Image(systemName: "arrow.clockwise")
+                                        .foregroundColor(Color.sensorNameColor1)
+                                        .padding(.top, 12)
+                                }
+                                .clipShape(Circle())
+                                .tint(.clear)
+                                .frame(width: 12, height: 12)
+                                .padding(0)
+                            }
+                        }
                     }
                 }.padding(EdgeInsets(top: 12, leading: 12, bottom: 8, trailing: 12))
             }.widgetURL(URL(string: "\(entry.tag.identifier.unwrapped)"))
         }
+    }
+
+    @ViewBuilder
+    private func measurementTimeView(for entry: WidgetEntry) -> some View {
+        Text(viewModel.measurementTime(from: entry))
+            .foregroundColor(Color.sensorNameColor1)
+            .font(.custom(
+                Constants.muliRegular.rawValue,
+                size: canShowBackground ? 10 : 14,
+                relativeTo: .body
+            ))
+            .minimumScaleFactor(0.5)
     }
 }
 

--- a/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalSettings.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalSettings.swift
@@ -25,6 +25,7 @@ public extension Notification.Name {
     static let LimitAlertNotificationsSettingsDidChange =
         Notification.Name("LimitAlertNotificationsSettingsDidChange")
     static let DashboardSensorOrderDidChange = Notification.Name("DashboardSensorOrderDidChange")
+    static let WidgetRefreshIntervalDidChange = Notification.Name("WidgetRefreshIntervalDidChange")
 }
 
 public enum DashboardTypeKey: String {
@@ -74,6 +75,8 @@ public protocol RuuviLocalSettings {
     var chartStatsOn: Bool { get set }
     var chartShowAll: Bool { get set }
     var networkPullIntervalSeconds: Int { get set }
+    var widgetRefreshIntervalMinutes: Int { get set }
+    var forceRefreshWidget: Bool { get set }
     var networkPruningIntervalHours: Int { get set }
     var experimentalFeaturesEnabled: Bool { get set }
     var cloudModeEnabled: Bool { get set }

--- a/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalSettingsUserDefaults.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalSettingsUserDefaults.swift
@@ -316,6 +316,22 @@ final class RuuviLocalSettingsUserDefaults: RuuviLocalSettings {
     @UserDefault("SettingsUserDefaults.networkPullIntervalMinutes", defaultValue: 60)
     var networkPullIntervalSeconds: Int
 
+    @UserDefault("SettingsUserDefaults.widgetRefreshIntervalMinutes", defaultValue: 60)
+    var widgetRefreshIntervalMinutes: Int {
+        didSet {
+            NotificationCenter
+                .default
+                .post(
+                    name: .WidgetRefreshIntervalDidChange,
+                    object: self,
+                    userInfo: nil
+                )
+        }
+    }
+
+    @UserDefault("SettingsUserDefaults.forceRefreshWidget", defaultValue: false)
+    var forceRefreshWidget: Bool
+
     @UserDefault("SettingsUserDefaults.networkPruningIntervalHours", defaultValue: 240)
     var networkPruningIntervalHours: Int
 


### PR DESCRIPTION
- Default refresh interval is 1h.
- Can be modified from 'Defaults' flag from dev build for testing purpose. 
- Manual refresh can be done by reload button which is present on iOS 17 and above. Note that refreshing manual only updates the widget being refreshed, not all if users have more than one widget.
- Moving the app to background always refresh all widgets. 