### PR TITLE
fix: Retry for failed sign in attempt #2094

### DIFF
--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/SignIn/Assembly/SignInModuleFactory.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/SignIn/Assembly/SignInModuleFactory.swift
@@ -30,6 +30,7 @@ class SignInModuleFactoryImpl: SignInModuleFactory {
         presenter.cloudSyncService = r.resolve(RuuviServiceCloudSync.self)
         presenter.cloudSyncDaemon = r.resolve(RuuviDaemonCloudSync.self)
         presenter.cloudNotificationService = r.resolve(RuuviServiceCloudNotification.self)
+        presenter.authService = r.resolve(RuuviServiceAuth.self)
         presenter.settings = r.resolve(RuuviLocalSettings.self)
 
         view.output = presenter

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/SignIn/View/SignInViewInput.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/SignIn/View/SignInViewInput.swift
@@ -10,4 +10,5 @@ protocol SignInViewInput: ViewInput {
     func showFailedToGetRequestedEmail()
     func showInvalidTokenEntered()
     func showInvalidEmailEntered()
+    func showUnexpectedHTTPStatusCodeError()
 }

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/SignIn/View/SignInViewOutput.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/SignIn/View/SignInViewOutput.swift
@@ -6,4 +6,5 @@ protocol SignInViewOutput {
     func viewDidTapRequestCodeButton(for email: String?)
     func viewDidTapEnterCodeManually(code: String)
     func viewDidTapUseWithoutAccount()
+    func viewDidTapOkFromUnexpectedHTTPStatusCodeError()
 }

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/SignIn/View/UI/SignInViewController.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/SignIn/View/UI/SignInViewController.swift
@@ -156,6 +156,18 @@ extension SignInViewController: SignInViewInput {
         alertVC.addAction(UIAlertAction(title: RuuviLocalization.ok, style: .cancel, handler: nil))
         present(alertVC, animated: true)
     }
+
+    func showUnexpectedHTTPStatusCodeError() {
+        let message = RuuviLocalization.RuuviCloudApiError.unexpectedHTTPStatusCodeShouldRetry
+        let alertVC = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertVC.addAction(UIAlertAction(
+            title: RuuviLocalization.ok,
+            style: .cancel,
+            handler: { [weak self] _ in
+                self?.output.viewDidTapOkFromUnexpectedHTTPStatusCodeError()
+        }))
+        present(alertVC, animated: true)
+    }
 }
 
 extension SignInViewController: SignInViewDelegate {

--- a/Apps/RuuviStation/Sources/Extensions/Errors/RuuviCloudApiError+LocalizedError.swift
+++ b/Apps/RuuviStation/Sources/Extensions/Errors/RuuviCloudApiError+LocalizedError.swift
@@ -13,6 +13,8 @@ extension RuuviCloudApiError: LocalizedError {
             RuuviLocalization.RuuviCloudApiError.failedToGetDataFromResponse
         case .unexpectedHTTPStatusCode:
             RuuviLocalization.RuuviCloudApiError.unexpectedHTTPStatusCode
+        case .unexpectedHTTPStatusCodeShouldRetry:
+            RuuviLocalization.RuuviCloudApiError.unexpectedHTTPStatusCodeShouldRetry
         case let .api(code):
             code.localizedDescription
         case let .networking(error):
@@ -20,6 +22,8 @@ extension RuuviCloudApiError: LocalizedError {
         case let .parsing(error):
             error.localizedDescription
         case .unauthorized:
+            nil
+        case .badParameters:
             nil
         }
     }

--- a/Packages/RuuviCloud/Sources/RuuviCloud/RuuviCloudApiError.swift
+++ b/Packages/RuuviCloud/Sources/RuuviCloud/RuuviCloudApiError.swift
@@ -6,7 +6,9 @@ public enum RuuviCloudApiError: Error {
     case parsing(Error)
     case api(RuuviCloudApiErrorCode)
     case emptyResponse
-    case unexpectedHTTPStatusCode
+    case unexpectedHTTPStatusCode(Int)
+    case unexpectedHTTPStatusCodeShouldRetry(Int)
     case failedToGetDataFromResponse
     case unauthorized
+    case badParameters
 }

--- a/Packages/RuuviCloud/Sources/RuuviCloudPure/RuuviCloudPure.swift
+++ b/Packages/RuuviCloud/Sources/RuuviCloudPure/RuuviCloudPure.swift
@@ -1177,9 +1177,10 @@ public final class RuuviCloudPure: RuuviCloud {
             return promise.future
         }
 
-        guard let type = request.type, let requestBody = request.requestBodyData
+        guard let type = request.type,
+              let requestBody = request.requestBodyData
         else {
-            promise.fail(error: .api(.unexpectedHTTPStatusCode))
+            promise.fail(error: .api(.badParameters))
             return promise.future
         }
 

--- a/Packages/RuuviService/Sources/RuuviServiceCloudSync/RuuviServiceCloudSyncImpl.swift
+++ b/Packages/RuuviService/Sources/RuuviServiceCloudSync/RuuviServiceCloudSyncImpl.swift
@@ -209,6 +209,8 @@ public final class RuuviServiceCloudSyncImpl: RuuviServiceCloudSync {
         syncSensors().on(success: { [weak self] _ in
             self?.ruuviLocalSyncState.setSyncDate(Date())
             promise.succeed(value: true)
+        }, failure: { error in
+            promise.fail(error: error)
         })
         return promise.future
     }
@@ -226,7 +228,8 @@ public final class RuuviServiceCloudSyncImpl: RuuviServiceCloudSync {
                 switch cloudError {
                 case .api(.unauthorized):
                     self?.postNotification()
-                default: break
+                default:
+                    promise.fail(error: .ruuviCloud(cloudError))
                 }
             default: break
             }
@@ -498,6 +501,8 @@ public final class RuuviServiceCloudSyncImpl: RuuviServiceCloudSync {
                     promise.fail(error: error)
                 })
             })
+        }, failure: { error in
+            promise.fail(error: .ruuviCloud(error))
         })
         return promise.future
     }


### PR DESCRIPTION
- Retry once in case of error in sensor dense endpoint from sign in flow.
- For next error show a dialog and clear previous session on OK tap so that user can start again.