### PR TITLE
fix: Alert bell blinks even if data is new #2140

### DIFF
--- a/Packages/RuuviNotifier/Sources/RuuviNotifierImpl/RuuviNotifierImpl+Process.swift
+++ b/Packages/RuuviNotifier/Sources/RuuviNotifierImpl/RuuviNotifierImpl+Process.swift
@@ -147,7 +147,8 @@ public extension RuuviNotifierImpl {
             case .cloudConnection:
                 let isCloudConnection = processCloudConnection(
                     alertType: type,
-                    identifier: identifier
+                    identifier: identifier,
+                    record: record
                 )
                 isTriggered = isTriggered || isCloudConnection
                 notify(
@@ -410,7 +411,8 @@ extension RuuviNotifierImpl {
 
     private func processCloudConnection(
         alertType: AlertType,
-        identifier: MACIdentifier?
+        identifier: MACIdentifier?,
+        record: RuuviTagSensorRecord
     ) -> Bool {
         guard let identifier else { return false }
 
@@ -424,19 +426,8 @@ extension RuuviNotifierImpl {
                 byAdding: .second, value: -Int(unseenDuration), to: Date()
             ) ?? Date()
 
-            // Check the last successful system sync with the cloud
-            if let lastSystemCloudSyncDate = localSyncState.getSyncDate() {
-                // If the sync date is earlier than our threshold, don't trigger the alert
-                if lastSystemCloudSyncDate < thresholdDateTime {
-                    return false
-                }
-            }
-
-            // If the system sync is within our threshold, check the measurement date
-            if let measurementDate = localSyncState.getSyncDate(for: identifier) {
-                // If the measurement date is earlier than our threshold, trigger the alert
-                return measurementDate < thresholdDateTime
-            }
+            // If the measurement date is earlier than our threshold, trigger the alert
+            return record.date < thresholdDateTime
         }
 
         // Default case, don't trigger alert

--- a/Packages/RuuviService/Sources/RuuviServiceCloudSync/RuuviServiceCloudSyncImpl.swift
+++ b/Packages/RuuviService/Sources/RuuviServiceCloudSync/RuuviServiceCloudSyncImpl.swift
@@ -354,10 +354,6 @@ public final class RuuviServiceCloudSyncImpl: RuuviServiceCloudSync {
         syncRecordsOperation(for: sensor, since: since)
             .on(success: { [weak self] result in
                 self?.ruuviLocalSyncState.setDownloadFullHistory(for: sensor.macId, downloadFull: false)
-                self?.ruuviLocalSyncState.setSyncDate(
-                    Date(),
-                    for: sensor.macId
-                )
                 promise.succeed(value: result)
             }, failure: { error in
                 promise.fail(error: error)
@@ -651,6 +647,10 @@ public final class RuuviServiceCloudSyncImpl: RuuviServiceCloudSync {
                 if sSelf.ruuviLocalSettings.cloudModeEnabled || isMeasurementNew {
                     sSelf.ruuviPool.updateLast(cloudRecord).on(success: { _ in
                         sSelf.ruuviLocalSyncState.setSyncStatus(.complete, for: ruuviTag.id.mac)
+                        sSelf.ruuviLocalSyncState.setSyncDate(
+                            Date(),
+                            for: ruuviTag.id.mac
+                        )
                         promise.succeed(value: true)
                     }, failure: { error in
                         sSelf.ruuviLocalSyncState.setSyncStatus(.onError, for: ruuviTag.id.mac)
@@ -664,6 +664,10 @@ public final class RuuviServiceCloudSyncImpl: RuuviServiceCloudSync {
                 // If no record found, create a new record
                 self?.ruuviPool.createLast(cloudRecord).on(success: { [weak self] _ in
                     self?.ruuviLocalSyncState.setSyncStatus(.complete, for: ruuviTag.id.mac)
+                    self?.ruuviLocalSyncState.setSyncDate(
+                        Date(),
+                        for: ruuviTag.id.mac
+                    )
                     promise.succeed(value: true)
                 }, failure: { [weak self] error in
                     self?.ruuviLocalSyncState.setSyncStatus(.onError, for: ruuviTag.id.mac)


### PR DESCRIPTION
Fixes the issue where alert bell keeps blinking if there are new data points available for offline alerts