### PR TITLE
fix: Move cloud sync daemon start call to applicationDidBecomeActive

### DIFF
--- a/Packages/RuuviDaemon/Sources/RuuviDaemon/RuuviDaemonCloudSync.swift
+++ b/Packages/RuuviDaemon/Sources/RuuviDaemon/RuuviDaemonCloudSync.swift
@@ -3,6 +3,7 @@ import Foundation
 public protocol RuuviDaemonCloudSync {
     func start()
     func stop()
+    func isRunning() -> Bool
     func refreshImmediately()
     func refreshLatestRecord()
 }

--- a/Packages/RuuviDaemon/Sources/RuuviDaemonCloudSync/RuuviDaemonCloudSyncWorker.swift
+++ b/Packages/RuuviDaemon/Sources/RuuviDaemonCloudSync/RuuviDaemonCloudSyncWorker.swift
@@ -7,6 +7,7 @@ class RuuviDaemonCloudSyncWorker: RuuviDaemonWorker, RuuviDaemonCloudSync {
     private var localSyncState: RuuviLocalSyncState
     private let cloudSyncService: RuuviServiceCloudSync
     private var pullTimer: Timer?
+    private var running = false
 
     init(
         localSettings: RuuviLocalSettings,
@@ -34,6 +35,7 @@ class RuuviDaemonCloudSyncWorker: RuuviDaemonWorker, RuuviDaemonCloudSync {
             )
             RunLoop.current.add(timer, forMode: .common)
             sSelf.pullTimer = timer
+            sSelf.running = true
         }
     }
 
@@ -51,9 +53,8 @@ class RuuviDaemonCloudSyncWorker: RuuviDaemonWorker, RuuviDaemonCloudSync {
         )
     }
 
-    @objc private func stopDaemon() {
-        pullTimer?.invalidate()
-        stopWork()
+    func isRunning() -> Bool {
+        running
     }
 
     @objc
@@ -67,5 +68,11 @@ class RuuviDaemonCloudSyncWorker: RuuviDaemonWorker, RuuviDaemonCloudSync {
         DispatchQueue.global(qos: .default).async { [weak self] in
             self?.cloudSyncService.refreshLatestRecord()
         }
+    }
+
+    @objc private func stopDaemon() {
+        pullTimer?.invalidate()
+        stopWork()
+        running = false
     }
 }


### PR DESCRIPTION
This prevents cloud sync daemon to wake up when things like background scanning may wake up app for processing background operations. #1545 