### PR TITLE
task: [GATT] Air autosync UX improvements

### DIFF
--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Full Sensor Card/Submodules/Graph/Interactor/CardsGraphViewInteractor.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Full Sensor Card/Submodules/Graph/Interactor/CardsGraphViewInteractor.swift
@@ -164,6 +164,17 @@ extension CardsGraphViewInteractor: CardsGraphViewInteractorInput {
         return gattService.isSyncingLogsQueued(with: luid.value)
     }
 
+    func hasLoggedFirstAutoSyncGattHistoryForRuuviAir() -> Bool {
+        localSyncState.hasLoggedFirstAutoSyncGattHistoryForRuuviAir(for: ruuviTagSensor.macId)
+    }
+
+    func setHasLoggedFirstAutoSyncGattHistoryForRuuviAir(_ logged: Bool) {
+        localSyncState.setHasLoggedFirstAutoSyncGattHistoryForRuuviAir(
+            logged,
+            for: ruuviTagSensor.macId
+        )
+    }
+
     func syncRecords(progress: ((BTServiceProgress) -> Void)?) -> Future<Void, RUError> {
         let promise = Promise<Void, RUError>()
         guard let luid = ruuviTagSensor.luid
@@ -219,7 +230,9 @@ extension CardsGraphViewInteractor: CardsGraphViewInteractorInput {
         }
         let op = gattService.stopGattSync(for: luid.value)
         op.on(success: { [weak self] response in
-            self?.gattSyncInterruptedByUser = true
+            if response {
+                self?.gattSyncInterruptedByUser = true
+            }
             promise.succeed(value: response)
         }, failure: { error in
             promise.fail(error: .ruuviService(error))

--- a/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Full Sensor Card/Submodules/Graph/Interactor/CardsGraphViewInteractorInput.swift
+++ b/Apps/RuuviStation/Sources/Classes/Presentation/Modules/Full Sensor Card/Submodules/Graph/Interactor/CardsGraphViewInteractorInput.swift
@@ -21,6 +21,8 @@ protocol CardsGraphViewInteractorInput: AnyObject {
     func stopSyncRecords() -> Future<Bool, RUError>
     func isSyncingRecords() -> Bool
     func isSyncingRecordsQueued() -> Bool
+    func hasLoggedFirstAutoSyncGattHistoryForRuuviAir() -> Bool
+    func setHasLoggedFirstAutoSyncGattHistoryForRuuviAir(_ logged: Bool)
     func deleteAllRecords(for sensor: RuuviTagSensor) -> Future<Void, RUError>
     func updateChartShowMinMaxAvgSetting(with show: Bool)
 }

--- a/Packages/RuuviDaemon/Sources/RuuviDaemonOperation/AsyncOperation.swift
+++ b/Packages/RuuviDaemon/Sources/RuuviDaemonOperation/AsyncOperation.swift
@@ -43,8 +43,10 @@ extension AsyncOperation {
             state = .finished
             return
         }
-        main()
+        // Mark as executing before `main()` to avoid finishing-state races
+        // when async APIs can invoke callbacks immediately.
         state = .executing
+        main()
     }
 
     override func cancel() {

--- a/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalSyncState.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocal/RuuviLocalSyncState.swift
@@ -33,6 +33,8 @@ public protocol RuuviLocalSyncState {
     func getSyncDate(for macId: MACIdentifier?) -> Date?
     func setGattSyncDate(_ date: Date?, for macId: MACIdentifier?)
     func getGattSyncDate(for macId: MACIdentifier?) -> Date?
+    func setHasLoggedFirstAutoSyncGattHistoryForRuuviAir(_ logged: Bool, for macId: MACIdentifier?)
+    func hasLoggedFirstAutoSyncGattHistoryForRuuviAir(for macId: MACIdentifier?) -> Bool
     func setSyncDate(_ date: Date?)
     func getSyncDate() -> Date?
     func setDownloadFullHistory(for macId: MACIdentifier?, downloadFull: Bool?)

--- a/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalSyncStateUserDefaults.swift
+++ b/Packages/RuuviLocal/Sources/RuuviLocalUserDefaults/RuuviLocalSyncStateUserDefaults.swift
@@ -8,6 +8,7 @@ final class RuuviLocalSyncStateUserDefaults: RuuviLocalSyncState {
     private let syncDateAllIDKey = "RuuviLocalSyncStateUserDefaults.syncDateAllIDKey."
     private let fullHistorySyncPrefix = "RuuviLocalSyncStateUserDefaults.fullHistorySyncPrefix."
     private let gattSyncDatePrefix = "RuuviLocalSyncStateUserDefaults.gattSyncDate."
+    private let firstAutoGattSyncLogPrefix = "RuuviLocalSyncStateUserDefaults.firstAutoGattSyncLog."
     private var syncingEnqueue: [AnyMACIdentifier] = []
 
     func setSyncStatus(_ status: NetworkSyncStatus) {
@@ -64,6 +65,16 @@ final class RuuviLocalSyncStateUserDefaults: RuuviLocalSyncState {
     func getGattSyncDate(for macId: MACIdentifier?) -> Date? {
         guard let macId else { assertionFailure(); return nil }
         return UserDefaults.standard.value(forKey: gattSyncDatePrefix + macId.mac) as? Date
+    }
+
+    func setHasLoggedFirstAutoSyncGattHistoryForRuuviAir(_ logged: Bool, for macId: MACIdentifier?) {
+        guard let macId else { return }
+        UserDefaults.standard.set(logged, forKey: firstAutoGattSyncLogPrefix + macId.mac)
+    }
+
+    func hasLoggedFirstAutoSyncGattHistoryForRuuviAir(for macId: MACIdentifier?) -> Bool {
+        guard let macId else { return false }
+        return UserDefaults.standard.bool(forKey: firstAutoGattSyncLogPrefix + macId.mac)
     }
 
     func setSyncDate(_ date: Date?) {

--- a/Packages/RuuviService/Sources/RuuviService/AsyncOperation.swift
+++ b/Packages/RuuviService/Sources/RuuviService/AsyncOperation.swift
@@ -43,8 +43,10 @@ extension AsyncOperation {
             state = .finished
             return
         }
-        main()
+        // Mark as executing before `main()` to avoid finishing-state races
+        // when async APIs can invoke callbacks immediately.
         state = .executing
+        main()
     }
 
     override open func cancel() {

--- a/Packages/RuuviService/Sources/RuuviServiceGATT/Queue/GATTServiceQueue.swift
+++ b/Packages/RuuviService/Sources/RuuviServiceGATT/Queue/GATTServiceQueue.swift
@@ -84,14 +84,15 @@ public final class GATTServiceQueue: GATTService {
     @discardableResult
     public func stopGattSync(for uuid: String) -> Future<Bool, RuuviServiceError> {
         let promise = Promise<Bool, RuuviServiceError>()
-        if isSyncingLogs(with: uuid) {
-            if let operation = queue.operations.filter({ ($0 as? RuuviTagReadLogsOperation)?.uuid == uuid }).first {
-                if let queueOperation = operation as? RuuviTagReadLogsOperation {
-                    queueOperation.stopSync()
-                }
-                operation.cancel()
-                promise.succeed(value: operation.isCancelled)
+        if let operation = queue.operations
+            .first(where: { ($0 as? RuuviTagReadLogsOperation)?.uuid == uuid }) {
+            if let queueOperation = operation as? RuuviTagReadLogsOperation {
+                queueOperation.stopSync()
             }
+            operation.cancel()
+            promise.succeed(value: operation.isCancelled)
+        } else {
+            promise.succeed(value: false)
         }
         return promise.future
     }


### PR DESCRIPTION
- Sync first time graph is opened, and from next instances sync only if last measurements is unavailable or older than 5 minutes.
- "Connecting" text may stay forever even after timeout.